### PR TITLE
fix(fetch): always set data field, even on `status.ok == false`

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -33,14 +33,12 @@ export async function fetch<T>(
     const resp = await fetchRaw(url, init);
     const contentType = resp.headers.get("content-type") || "";
 
-    if (resp.ok) {
-      // Parse the response as JSON if the content type is JSON
-      if (contentType.includes("application/json")) {
-        data = await resp.json();
-      } else {
-        // Otherwise, return however the response was read
-        data = (await resp.text()) as unknown as T;
-      }
+    // Parse the response as JSON if the content type is JSON
+    if (contentType.includes("application/json")) {
+      data = await resp.json();
+    } else {
+      // Otherwise, return however the response was read
+      data = (await resp.text()) as unknown as T;
     }
 
     return {


### PR DESCRIPTION
just because we're not ok, doesn't mean the data payload is helpful in Kubernetes case, this contains the exact why of a potential error.

will need some additional testing, and use cases. like if we're getting a failed connection, or there's no body to the non-200 response.

in theory we can also try to populate the message, but the statusText is an HTTP text error, and the body payload is something else.