### PR TITLE
ForceApply

### DIFF
--- a/src/fluent/index.test.ts
+++ b/src/fluent/index.test.ts
@@ -140,6 +140,13 @@ describe("Kube", () => {
     expect(result).toEqual(fakeResource);
   });
 
+  it("should allow ForceApply of deep partials", async () => {
+    const kube = K8s(Pod);
+    let result = await kube.ForceApply({ metadata: { name: "fake" }, spec: { priority: 3 } });
+    result = await kube.ForceApply({ metadata: { name: "fake" }, spec: { priority: 3 } });
+    expect(result).toEqual(fakeResource);
+  });
+
   it("should throw an error if a Delete failed for a reason other than Not Found", async () => {
     mockedKubeExec.mockRejectedValueOnce({ status: 500 }); // Internal Server Error on first call
     const kube = K8s(Pod);

--- a/src/fluent/index.ts
+++ b/src/fluent/index.ts
@@ -105,6 +105,11 @@ export function K8s<T extends GenericClass, K extends KubernetesObject = Instanc
     return k8sExec(model, filters, "APPLY", resource);
   }
 
+  async function ForceApply(resource: PartialDeep<K>): Promise<K> {
+    syncFilters(resource as K);
+    return k8sExec(model, filters, "FORCEAPPLY", resource);
+  }
+
   async function Create(resource: K): Promise<K> {
     syncFilters(resource);
     return k8sExec(model, filters, "POST", resource);
@@ -123,5 +128,5 @@ export function K8s<T extends GenericClass, K extends KubernetesObject = Instanc
     return ExecWatch(model, filters, callback);
   }
 
-  return { InNamespace, Apply, Create, Patch, ...withFilters };
+  return { InNamespace, ForceApply, Apply, Create, Patch, ...withFilters };
 }

--- a/src/fluent/types.ts
+++ b/src/fluent/types.ts
@@ -16,7 +16,15 @@ export enum WatchPhase {
   Deleted = "DELETED",
 }
 
-export type FetchMethods = "GET" | "APPLY" | "POST" | "PUT" | "DELETE" | "PATCH" | "WATCH";
+export type FetchMethods =
+  | "GET"
+  | "APPLY"
+  | "FORCEAPPLY"
+  | "POST"
+  | "PUT"
+  | "DELETE"
+  | "PATCH"
+  | "WATCH";
 
 export interface Filters {
   kindOverride?: GroupVersionKind;
@@ -62,6 +70,14 @@ export type K8sUnfilteredActions<K extends KubernetesObject> = {
    * @returns
    */
   Apply: (resource: PartialDeep<K>) => Promise<K>;
+
+  /**
+   * Perform a server-side apply of the provided K8s resource (wtth Force flag set to true)
+   *
+   * @param resource
+   * @returns
+   */
+  ForceApply: (resource: PartialDeep<K>) => Promise<K>;
 
   /**
    * Create the provided K8s resource or throw an error if it already exists.

--- a/src/fluent/utils.ts
+++ b/src/fluent/utils.ts
@@ -129,12 +129,13 @@ export async function k8sExec<T extends GenericClass, K>(
       (opts.headers as Headers).set("Content-Type", PatchStrategy.JsonPatch);
       break;
 
+    case "FORCEAPPLY":
     case "APPLY":
       (opts.headers as Headers).set("Content-Type", SSA_CONTENT_TYPE);
+      url.searchParams.set("force", opts.method === "FORCEAPPLY" ? "true" : "false");
       opts.method = "PATCH";
       url.searchParams.set("fieldManager", "pepr");
       url.searchParams.set("fieldValidation", "Strict");
-      url.searchParams.set("force", "false");
       break;
   }
 


### PR DESCRIPTION
added .ForceApply(), that will overwrite (when it can) versus failing if there's a conflict like .Apply().

Functions exactly like Apply() but will set this: 
      url.searchParams.set("force", opts.method === "FORCEAPPLY" ? "true" : "false");

This saves the user from using a JSON patch with .Patch() and letting us use SSA