### PR TITLE
feat: force options on apply

### DIFF
--- a/src/fluent/apply.ts
+++ b/src/fluent/apply.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+/**
+ * Configuration for the apply function.
+ */
+export type ApplyCfg = {
+  /**
+   * Force the apply to be a create.
+   */
+  force?: boolean;
+};

--- a/src/fluent/index.test.ts
+++ b/src/fluent/index.test.ts
@@ -48,7 +48,7 @@ describe("Kube", () => {
     metadata: {
       name: "fake",
       namespace: "default",
-      managedFields: generateFakePodManagedFields("kubectl"),
+      managedFields: generateFakePodManagedFields("pepr"),
     },
   };
 
@@ -186,7 +186,7 @@ describe("Kube", () => {
     const kube = K8s(Pod);
     const result = await kube.Apply(
       {
-        metadata: { name: "fake", managedFields: generateFakePodManagedFields("pepr") },
+        metadata: { name: "fake", managedFields: generateFakePodManagedFields("kubectl") },
         spec: { priority: 3 },
       },
       { force: true },

--- a/src/fluent/index.test.ts
+++ b/src/fluent/index.test.ts
@@ -8,8 +8,50 @@ import { k8sExec } from "./utils";
 // Setup mocks
 jest.mock("./utils");
 
+const generateFakePodManagedFields = (manager: string) => {
+  return [
+    {
+      apiVersion: "v1",
+      fieldsType: "FieldsV1",
+      fieldsV1: {
+        "f:metadata": {
+          "f:labels": {
+            "f:fake": {},
+          },
+          "f:spec": {
+            "f:containers": {
+              'k:{"name":"fake"}': {
+                "f:image": {},
+                "f:name": {},
+                "f:resources": {
+                  "f:limits": {
+                    "f:cpu": {},
+                    "f:memory": {},
+                  },
+                  "f:requests": {
+                    "f:cpu": {},
+                    "f:memory": {},
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      manager: manager,
+      operation: "Apply",
+    },
+  ];
+};
 describe("Kube", () => {
-  const fakeResource = { metadata: { name: "fake", namespace: "default" } };
+  const fakeResource = {
+    metadata: {
+      name: "fake",
+      namespace: "default",
+      managedFields: generateFakePodManagedFields("kubectl"),
+    },
+  };
+
   const mockedKubeExec = jest.mocked(k8sExec).mockResolvedValue(fakeResource);
 
   beforeEach(() => {
@@ -137,6 +179,18 @@ describe("Kube", () => {
   it("should allow Apply of deep partials", async () => {
     const kube = K8s(Pod);
     const result = await kube.Apply({ metadata: { name: "fake" }, spec: { priority: 3 } });
+    expect(result).toEqual(fakeResource);
+  });
+
+  it("should allow force apply to resolve FieldManagerConflict", async () => {
+    const kube = K8s(Pod);
+    const result = await kube.Apply(
+      {
+        metadata: { name: "fake", managedFields: generateFakePodManagedFields("pepr") },
+        spec: { priority: 3 },
+      },
+      { force: true },
+    );
     expect(result).toEqual(fakeResource);
   });
 

--- a/src/fluent/index.ts
+++ b/src/fluent/index.ts
@@ -11,6 +11,7 @@ import { GenericClass } from "../types";
 import { Filters, K8sInit, Paths, WatchAction } from "./types";
 import { k8sExec } from "./utils";
 import { ExecWatch, WatchCfg } from "./watch";
+import { ApplyCfg } from "./apply";
 
 /**
  * Kubernetes fluent API inspired by Kubectl. Pass in a model, then call filters and actions on it.
@@ -100,9 +101,12 @@ export function K8s<T extends GenericClass, K extends KubernetesObject = Instanc
     }
   }
 
-  async function Apply(resource: PartialDeep<K>): Promise<K> {
+  async function Apply(
+    resource: PartialDeep<K>,
+    applyCfg: ApplyCfg = { force: false },
+  ): Promise<K> {
     syncFilters(resource as K);
-    return k8sExec(model, filters, "APPLY", resource);
+    return k8sExec(model, filters, "APPLY", resource, applyCfg);
   }
 
   async function Create(resource: K): Promise<K> {

--- a/src/fluent/types.ts
+++ b/src/fluent/types.ts
@@ -7,6 +7,7 @@ import type { PartialDeep } from "type-fest";
 
 import { GenericClass, GroupVersionKind } from "../types";
 import { WatchCfg, WatchController } from "./watch";
+import { ApplyCfg } from "./apply";
 
 /**
  * The Phase matched when using the K8s Watch API.
@@ -65,7 +66,7 @@ export type K8sUnfilteredActions<K extends KubernetesObject> = {
    * @param resource
    * @returns
    */
-  Apply: (resource: PartialDeep<K>) => Promise<K>;
+  Apply: (resource: PartialDeep<K>, applyCfg?: ApplyCfg) => Promise<K>;
 
   /**
    * Create the provided K8s resource or throw an error if it already exists.

--- a/src/fluent/utils.test.ts
+++ b/src/fluent/utils.test.ts
@@ -33,7 +33,8 @@ describe("pathBuilder Function", () => {
       "/api/v1/namespaces/default/pods/mypod?fieldSelector=iamafield%3Diamavalue&labelSelector=iamalabel%3Diamalabelvalue",
       serverUrl,
     );
-    expect(result).toEqual(expected);
+
+    expect(result.toString()).toEqual(expected.toString());
   });
 
   it("Version not specified in a Kind", () => {

--- a/src/fluent/utils.ts
+++ b/src/fluent/utils.ts
@@ -9,6 +9,7 @@ import { fetch } from "../fetch";
 import { modelToGroupVersionKind } from "../kinds";
 import { GenericClass } from "../types";
 import { FetchMethods, Filters } from "./types";
+import { ApplyCfg } from "./apply";
 
 const SSA_CONTENT_TYPE = "application/apply-patch+yaml";
 
@@ -123,6 +124,7 @@ export async function k8sExec<T extends GenericClass, K>(
   filters: Filters,
   method: FetchMethods,
   payload?: K | unknown,
+  applyCfg: ApplyCfg = { force: false },
 ) {
   const { opts, serverUrl } = await k8sCfg(method);
   const url = pathBuilder(serverUrl, model, filters, method === "POST");
@@ -137,7 +139,7 @@ export async function k8sExec<T extends GenericClass, K>(
       opts.method = "PATCH";
       url.searchParams.set("fieldManager", "pepr");
       url.searchParams.set("fieldValidation", "Strict");
-      url.searchParams.set("force", "false");
+      url.searchParams.set("force", applyCfg.force ? "true" : "false");
       break;
   }
 


### PR DESCRIPTION
## Description


@lucasrod16  discovered a bug in Pepr when trying to `apply` a secret that was initially created by Zarf:

```typescript
  try {
    await K8s(kind.Secret).Apply({
      metadata: {
        name: secretName,
        namespace: ns,
      },
      data: {
        data: secret.data.data,
      },
    });
  } catch (err) {
    Log.error(
      `Error: Failed to update package secret '${secretName}' in namespace '${ns}'`,
    );
  }
  ```
  
  The error had to do with a `FieldManagerConflict`:
  
  ```
  "Apply failed with 1 conflict: conflict with \\\"zarf\\\" using v1: .data.data\",\"reason\":\"Conflict\",\"details\":{\"causes\":[{\"reason\":\"FieldManagerConflict\",\"message\":\"conflict with \\\"zarf\\\" using v1\",\"field\":\".data.data\"}]},\"code\":409},\"ok\":false,\"status\":409,\"statusText\":\"Conflict\"}"}
  ```
  
There should be more options exposed in the future but this initial patch it to unblock @lucasrod16 .

## Related Issue

Fixes #9 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/pepr/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed


  
  