### PR TITLE
fix: fork quicktype-core temporarily due to Node21 dep bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "fast-json-patch": "3.1.1",
         "http-status-codes": "2.3.0",
         "node-fetch": "2.7.0",
-        "quicktype-core": "23.0.76",
+        "quicktype-core": "github:defenseunicorns/temp-quicktype-fork#main",
         "type-fest": "4.5.0",
         "yargs": "17.7.2"
       },
@@ -10945,12 +10945,12 @@
     },
     "node_modules/quicktype-core": {
       "version": "23.0.76",
-      "resolved": "https://registry.npmjs.org/quicktype-core/-/quicktype-core-23.0.76.tgz",
-      "integrity": "sha512-QinZRNovSTQcFuhRKxeHb22eFmyucbG96EPaQDSbz9qvIPxUhs1BZviNc8HAkHWYFqTSET/xZcEoHpm1DeDbRg==",
+      "resolved": "git+ssh://git@github.com/defenseunicorns/temp-quicktype-fork.git#b19a629edbcda606096166cd1fd4f72ae2852a6d",
+      "license": "Apache-2.0",
       "dependencies": {
         "@glideapps/ts-necessities": "2.1.3",
         "@types/urijs": "^1.19.19",
-        "browser-or-node": "^2.1.1",
+        "browser-or-node": "github:defenseunicorns/browser-or-node#master",
         "collection-utils": "^1.0.1",
         "cross-fetch": "^4.0.0",
         "is-url": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "fast-json-patch": "3.1.1",
     "http-status-codes": "2.3.0",
     "node-fetch": "2.7.0",
-    "quicktype-core": "23.0.76",
+    "quicktype-core": "github:defenseunicorns/temp-quicktype-fork#main",
     "type-fest": "4.5.0",
     "yargs": "17.7.2"
   },


### PR DESCRIPTION
Apparently package.json overrides are not respected by npx, so having to fork quicktype until that is resolved.