### PR TITLE
fix: event types mixed up and add both types of events

### DIFF
--- a/src/kinds.test.ts
+++ b/src/kinds.test.ts
@@ -13,6 +13,10 @@ const testCases = [
     expected: { group: "events.k8s.io", version: "v1", kind: "Event" },
   },
   {
+    name: kind.CoreEvent,
+    expected: { group: "", version: "v1", kind: "Event" },
+  },
+  {
     name: kind.ClusterRole,
     expected: { group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole" },
   },

--- a/src/kinds.ts
+++ b/src/kinds.ts
@@ -27,11 +27,11 @@ const gvkMap: Record<string, GroupVersionKind> = {
    *
    * @see {@link https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#event-v1-core}
    */
-    CoreV1Event: {
-      kind: "Event",
-      version: "v1",
-      group: "",
-    },
+  CoreV1Event: {
+    kind: "Event",
+    version: "v1",
+    group: "",
+  },
   /**
    * Represents a K8s ClusterRole resource.
    * ClusterRole is a set of permissions that can be bound to a user or group in a cluster-wide scope.

--- a/src/kinds.ts
+++ b/src/kinds.ts
@@ -5,7 +5,7 @@ import { GenericClass, GroupVersionKind } from "./types";
 
 const gvkMap: Record<string, GroupVersionKind> = {
   /**
-   * Represents a K8s Event resource.
+   * Represents a K8s Event resource (new Event in the events.k8s.io API)
    * Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system.
    * Events have a limited retention time and triggers and messages may evolve with time. Event consumers should not
    * rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued
@@ -18,7 +18,20 @@ const gvkMap: Record<string, GroupVersionKind> = {
     version: "v1",
     group: "events.k8s.io",
   },
-
+  /**
+   * Represents a K8s Event resource (legacy core v1 Event, use the above one instead, it is more complete)
+   * Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system.
+   * Events have a limited retention time and triggers and messages may evolve with time. Event consumers should not
+   * rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued
+   * existence of events with that Reason. Events should be treated as informative, best-effort, supplemental data.
+   *
+   * @see {@link https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#event-v1-core}
+   */
+    CoreV1Event: {
+      kind: "Event",
+      version: "v1",
+      group: "",
+    },
   /**
    * Represents a K8s ClusterRole resource.
    * ClusterRole is a set of permissions that can be bound to a user or group in a cluster-wide scope.

--- a/src/kinds.ts
+++ b/src/kinds.ts
@@ -13,7 +13,7 @@ const gvkMap: Record<string, GroupVersionKind> = {
    *
    * @see {@link https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/}
    */
-  CoreV1Event: {
+  EventsV1Event: {
     kind: "Event",
     version: "v1",
     group: "events.k8s.io",

--- a/src/upstream.ts
+++ b/src/upstream.ts
@@ -3,7 +3,7 @@
 
 /** a is a collection of K8s types to be used within an action: `When(a.Configmap)` */
 export {
-  CoreV1Event as Event,
+  EventsV1Event as Event,
   V1APIService as APIService,
   V1CertificateSigningRequest as CertificateSigningRequest,
   V1ClusterRole as ClusterRole,

--- a/src/upstream.ts
+++ b/src/upstream.ts
@@ -3,6 +3,7 @@
 
 /** a is a collection of K8s types to be used within an action: `When(a.Configmap)` */
 export {
+  CoreV1Event as CoreEvent,
   EventsV1Event as Event,
   V1APIService as APIService,
   V1CertificateSigningRequest as CertificateSigningRequest,


### PR DESCRIPTION
from chatgpt, looks correct, we want to make sure we have the detail to make decisions to recreate a docker pull secret based on them changing remotely (ECR). The code currently gives you the correct object, but typed to the old object type causing mismatching.

---

### Differences between CoreV1Event and EventV1Event in Kubernetes

`CoreV1Event` and `EventV1Event` in Kubernetes refer to different versions and structures of events. Below is a comparison of the two:

#### CoreV1Event (`v1.Event`):
- Part of the `core/v1` API group.
- The original event resource type, present since early Kubernetes versions.
- Commonly used and interacted with via `kubectl get events`.
- Events are used primarily for debugging and do not guarantee comprehensive information about the cluster state.

#### EventV1Event (`events.k8s.io/v1.Event`):
- Introduced in later Kubernetes versions, starting as `events.k8s.io/v1beta1` in Kubernetes 1.10 and graduating to `events.k8s.io/v1` in Kubernetes 1.19.
- Provides an improved structure and additional features over `CoreV1Event`.
- Aims to offer more context and detailed information about events, enhancing the understanding of the cluster state.
- Features include event de-duplication and better event aggregation.

**Key Differences**:
- The primary differences lie in the API version and the details and structure of the event information.
- `EventV1Event` is preferable for more detailed event information and newer Kubernetes clusters.
- `CoreV1Event` is widely used for basic event information and is compatible with older Kubernetes versions.

**Considerations**:
- Choose based on the Kubernetes cluster version and the level of event detail required.
- For basic use cases, `CoreV1Event` is generally sufficient.
- For advanced event tracking and analysis, `EventV1Event` might be more suitable.

---

You can use this Markdown-formatted response for documentation purposes or any other suitable application.