### PR TITLE
feat: add `K8s().Raw()` function for arbitrary wrapped API calls

### DIFF
--- a/src/fluent/types.ts
+++ b/src/fluent/types.ts
@@ -105,7 +105,7 @@ export type K8sUnfilteredActions<K extends KubernetesObject> = {
    *
    * ```ts
    * import { V1APIGroup } from "@kubernetes/client-node";
-   * 
+   *
    * K8s(V1APIGroup).Raw("/api")
    * ```
    *

--- a/src/fluent/types.ts
+++ b/src/fluent/types.ts
@@ -96,6 +96,25 @@ export type K8sUnfilteredActions<K extends KubernetesObject> = {
    * @returns The patched resource
    */
   Patch: (payload: Operation[]) => Promise<K>;
+
+  /**
+   * Perform a raw GET request to the Kubernetes API. This is useful for calling endpoints that are not supported by the fluent API.
+   * This command mirrors the `kubectl get --raw` command.
+   *
+   * E.g.
+   *
+   * ```ts
+   * import { V1APIGroup } from "@kubernetes/client-node";
+   * 
+   * K8s(V1APIGroup).Raw("/api")
+   * ```
+   *
+   * will call the `/api` endpoint and is equivalent to `kubectl get --raw /api`.
+   *
+   * @param url the URL to call (e.g. /api)
+   * @returns
+   */
+  Raw: (url: string) => Promise<K>;
 };
 
 export type K8sWithFilters<K extends KubernetesObject> = K8sFilteredActions<K> & {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,4 +28,4 @@ export * from "./types";
 
 export * as K8sClientNode from "@kubernetes/client-node";
 
-export { fromEnv } from "./helpers";
+export { fromEnv, waitForCluster } from "./helpers";

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,6 @@ export { GenericKind } from "./types";
 
 export * from "./types";
 
-export * as K8sClientNode from "@kubernetes/client-node";
-
 // Export the upstream raw models
 export * as models from "@kubernetes/client-node/dist/gen/models/all";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,4 +28,7 @@ export * from "./types";
 
 export * as K8sClientNode from "@kubernetes/client-node";
 
+// Export the upstream raw models
+export * as models from "@kubernetes/client-node/dist/gen/models/all";
+
 export { fromEnv, waitForCluster } from "./helpers";


### PR DESCRIPTION
This exposes a `.Raw()` call that mirrors `kubectl get --raw` for performing advanced calls when the fluent API alone isn't enough. Also properly exports the `waitForCluster()` helper function and all generic K8s models under `models` for advanced usage.