### PR TITLE
chore: updated filepath to correctly handle absolute and relative paths

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -144,9 +144,11 @@ async function readOrFetchCrd(opts: GenerateOptions): Promise<CustomResourceDefi
   const { source, logFn } = opts;
   let filePath: string;
 
-  if (source[0] === "/") { // If the source is an absolute path
+  if (source[0] === "/") {
+    // If the source is an absolute path
     filePath = source;
-  } else { // If the source is a relative path
+  } else {
+    // If the source is a relative path
     filePath = path.join(process.cwd(), source);
   }
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -142,7 +142,13 @@ async function convertCRDtoTS(
  */
 async function readOrFetchCrd(opts: GenerateOptions): Promise<CustomResourceDefinition[]> {
   const { source, logFn } = opts;
-  const filePath = path.join(process.cwd(), source);
+  let filePath: string;
+
+  if (source[0] === "/") { // If the source is an absolute path
+    filePath = source;
+  } else { // If the source is a relative path
+    filePath = path.join(process.cwd(), source);
+  }
 
   // First try to read the source as a file
   try {


### PR DESCRIPTION
Updated filepath in generate.ts readOrFetchCrd function to check to see if the source path is absolute or relative and handle them correctly:

```ts
  if (source[0] === "/") { // If the source is an absolute path
    filePath = source;
  } else { // If the source is a relative path
    filePath = path.join(process.cwd(), source);
  }
 ```