### PR TITLE
chore: Ignore Type instantiation is excessively deep and possibly inf…

### DIFF
--- a/src/fluent/index.ts
+++ b/src/fluent/index.ts
@@ -46,6 +46,7 @@ export function K8s<T extends GenericClass, K extends KubernetesObject = Instanc
    */
   function WithField<P extends Paths<K>>(key: P, value: string) {
     filters.fields = filters.fields || {};
+    // @ts-ignore
     filters.fields[key] = value;
     return withFilters;
   }


### PR DESCRIPTION
After researching, we decided to ignore the error: "src/fluent/index.ts:49:5 - error TS2589: Type instantiation is excessively deep and possibly infinite" as we feel it is a false positive. 