### PR TITLE
feat: add `plural` to CRD generation

### DIFF
--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -152,6 +152,7 @@ describe("CRD Generate", () => {
       '  group: "example.com",',
       '  version: "v1",',
       '  kind: "Movie",',
+      '  plural: "movies",',
       "});",
     ];
     const expectedBookV1 = [
@@ -173,6 +174,7 @@ describe("CRD Generate", () => {
       '  group: "example.com",',
       '  version: "v1",',
       '  kind: "Book",',
+      '  plural: "books",',
       "});",
     ];
     const expectedBookV2 = expectedBookV1
@@ -252,6 +254,7 @@ describe("CRD Generate", () => {
       '  group: "example.com",',
       '  version: "v1",',
       '  kind: "Movie",',
+      '  plural: "movies",',
       "});",
     ];
     const expectedBookV1 = [
@@ -273,6 +276,7 @@ describe("CRD Generate", () => {
       '  group: "example.com",',
       '  version: "v1",',
       '  kind: "Book",',
+      '  plural: "books",',
       "});",
     ];
     const expectedBookV2 = expectedBookV1
@@ -311,6 +315,7 @@ describe("CRD Generate", () => {
       '  group: "example.com",',
       '  version: "v1",',
       '  kind: "Movie",',
+      '  plural: "movies",',
       "});",
     ];
     const expectedBookV1 = [
@@ -332,6 +337,7 @@ describe("CRD Generate", () => {
       '  group: "example.com",',
       '  version: "v1",',
       '  kind: "Book",',
+      '  plural: "books",',
       "});",
     ];
     const expectedBookV2 = expectedBookV1

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -111,6 +111,7 @@ async function convertCRDtoTS(
       processedLines.push(`  group: "${crd.spec.group}",`);
       processedLines.push(`  version: "${version}",`);
       processedLines.push(`  kind: "${name}",`);
+      processedLines.push(`  plural: "${crd.spec.names.plural}",`);
       processedLines.push(`});`);
     }
 


### PR DESCRIPTION
This adds `plural` to the CRD generation so that it can properly be used when generating URL paths to interact with K8s objects in a cluster.