### PR TITLE
build: revert quick-type core bc it breaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "fast-json-patch": "3.1.1",
         "http-status-codes": "2.3.0",
         "node-fetch": "2.7.0",
-        "quicktype-core": "23.0.161",
+        "quicktype-core": "23.0.158",
         "type-fest": "4.18.2",
         "yargs": "17.7.2"
       },
@@ -2842,6 +2842,11 @@
       "version": "1.11.15",
       "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.15.tgz",
       "integrity": "sha512-HP38xE+GuWGlbSRq9WrZkousaQ7dragtZCruBVMi0oX1migFZavZ3OROKHSkNp/9ouq82zrWtZpg18jFnVN96g=="
+    },
+    "node_modules/@types/urijs": {
+      "version": "1.19.25",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.25.tgz",
+      "integrity": "sha512-XOfUup9r3Y06nFAZh3WvO0rBU4OtlfPB/vgxpjg+NRdGU6CN6djdc6OEiH+PcqHCY6eFLo9Ista73uarf4gnBg=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -10556,11 +10561,12 @@
       ]
     },
     "node_modules/quicktype-core": {
-      "version": "23.0.161",
-      "resolved": "https://registry.npmjs.org/quicktype-core/-/quicktype-core-23.0.161.tgz",
-      "integrity": "sha512-xIco/FOJGgaRRgnm1OpCYU3+C1Hig9VFm4Zm02t32YJuKx11qmoMWoC4fj1kQJMecDBiI1ksMar4d8JrC3M0KQ==",
+      "version": "23.0.158",
+      "resolved": "https://registry.npmjs.org/quicktype-core/-/quicktype-core-23.0.158.tgz",
+      "integrity": "sha512-CY85z0eLyPlimpyZwfK2YHjrMyjckiILfffX07XMjSpJZ5Z/dOTWXqdiTf+IS172utvDUHNTYQHZY/eqPTwEbQ==",
       "dependencies": {
         "@glideapps/ts-necessities": "2.2.3",
+        "@types/urijs": "^1.19.25",
         "browser-or-node": "^3.0.0",
         "collection-utils": "^1.0.1",
         "cross-fetch": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "fast-json-patch": "3.1.1",
     "http-status-codes": "2.3.0",
     "node-fetch": "2.7.0",
-    "quicktype-core": "23.0.161",
+    "quicktype-core": "23.0.158",
     "type-fest": "4.18.2",
     "yargs": "17.7.2"
   },


### PR DESCRIPTION
https://github.com/defenseunicorns/kubernetes-fluent-client/actions/workflows/release.yml

An update QuickType Core broke our KFC Release pipeline

```bash
[Release: node_modules/quicktype-core/dist/input/JSONSchemaInput.d.ts#L1](https://github.com/defenseunicorns/kubernetes-fluent-client/commit/793ca7b03bc81756541cc513871728a24f1d4a9b#annotation_21521061930)
Could not find a declaration file for module 'urijs'. '/home/runner/work/kubernetes-fluent-client/kubernetes-fluent-client/node_modules/urijs/src/URI.js' implicitly has an 'any' type.
```