### PR TITLE
chore: update Log function error message

### DIFF
--- a/src/fluent/index.ts
+++ b/src/fluent/index.ts
@@ -139,7 +139,7 @@ export function K8s<T extends GenericClass, K extends KubernetesObject = Instanc
         podList.push(object);
       }
     } catch (e) {
-      throw new Error(e);
+      throw new Error(`Failed to get logs in KFC Logs function`);
     }
 
     const podModel = { ...model, name: "V1Pod" };


### PR DESCRIPTION
Currently the Log function does not return a helpful error message from the catch block. This should be updated to provide a readable and useful message.