### PR TITLE
chore: add permissions to commitlint workflow

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     types: [opened, edited, synchronize]
 
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   title_check:
     runs-on: ubuntu-latest
@@ -12,6 +15,11 @@ jobs:
       pull-requests: read
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     types: [opened, edited, synchronize]
 
-permissions:  # added using https://github.com/step-security/secure-repo
+permissions: # added using https://github.com/step-security/secure-repo
   contents: read
 
 jobs:


### PR DESCRIPTION
This should mitigate [this](https://github.com/defenseunicorns/kubernetes-fluent-client/security/code-scanning/3) vulnerability