### PR TITLE
chore: revert bc release failed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "http-status-codes": "2.3.0",
         "node-fetch": "2.7.0",
         "quicktype-core": "23.0.170",
-        "type-fest": "4.21.0",
+        "type-fest": "4.20.1",
         "yargs": "17.7.2"
       },
       "bin": {
@@ -11993,9 +11993,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.21.0.tgz",
-      "integrity": "sha512-ADn2w7hVPcK6w1I0uWnM//y1rLXZhzB9mr0a3OirzclKF1Wp6VzevUmzz/NRAWunOT6E8HrnpGY7xOfc6K57fA==",
+      "version": "4.20.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.20.1.tgz",
+      "integrity": "sha512-R6wDsVsoS9xYOpy8vgeBlqpdOyzJ12HNfQhC/aAKWM3YoCV9TtunJzh/QpkMgeDhkoynDcw5f1y+qF9yc/HHyg==",
       "engines": {
         "node": ">=16"
       },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "http-status-codes": "2.3.0",
     "node-fetch": "2.7.0",
     "quicktype-core": "23.0.170",
-    "type-fest": "4.21.0",
+    "type-fest": "4.20.1",
     "yargs": "17.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The typefest update is missing a depedency that blocks release