### PR TITLE
fix: keep alive on socket

### DIFF
--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -372,6 +372,9 @@ export class Watcher<T extends GenericClass> {
 
       // Make the actual request
       const response = await fetch(url, { ...opts });
+      response.body.on("socket", socket => {
+        socket.setKeepAlive(true, 1000);
+      });
 
       // Reset the pending reconnect flag
       this.#pendingReconnect = false;

--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -373,7 +373,7 @@ export class Watcher<T extends GenericClass> {
       // Make the actual request
       const response = await fetch(url, { ...opts });
       response.body.on("socket", socket => {
-        socket.setKeepAlive(true, 1000);
+        socket.setKeepAlive(true, 30 * 1000);
       });
 
       // Reset the pending reconnect flag


### PR DESCRIPTION
## Description

Enable keep-alive functionality on the `response.body` from the watch call. This will probe when the socket is idle, hopefully resulting in less missed events from the watcher.

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
