### PR TITLE
fix: errorHandler - should only schedulereconnect if using http2

### DIFF
--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -608,7 +608,9 @@ export class Watcher<T extends GenericClass> {
         clearInterval(this.$relistTimer);
         clearInterval(this.#resyncTimer);
         this.#streamCleanup();
-        this.#scheduleReconnect();
+        if(!this.#useHTTP2) {
+          this.#scheduleReconnect();
+        }
         this.#events.emit(WatchEvent.ABORT, err);
         return;
 

--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -608,7 +608,7 @@ export class Watcher<T extends GenericClass> {
         clearInterval(this.$relistTimer);
         clearInterval(this.#resyncTimer);
         this.#streamCleanup();
-        if(!this.#useHTTP2) {
+        if (!this.#useHTTP2) {
           this.#scheduleReconnect();
         }
         this.#events.emit(WatchEvent.ABORT, err);


### PR DESCRIPTION
## Description

 errorHandler - should only scheduleReconnect if using http2

## Related Issue

Fixes #440 

<!-- or -->

Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
