### PR TITLE
chore: codeowners to reference group

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,6 @@
-* @jeff-mccoy @cmwylie19 @btlghrants @schaeferka
+* @defenseunicorns/pepr
 
 # Additional privileged files
-/CODEOWNERS @jeff-mccoy @austenbryan
-/cosign.pub @jeff-mccoy @austenbryan
+/CODEOWNERS @jeff-mccoy @daveworth
+/cosign.pub @jeff-mccoy @daveworth
 /LICENSE @jeff-mccoy @austenbryan
-


### PR DESCRIPTION
## Description

Make `CODEOWNERS` reference `@defenseunicorns/pepr` instead of individuals. Adds @daveworth to file

## Related Issue

Fixes #480 

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
