### PR TITLE
chore: ignore breaking release of @kubernetes/client-node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: "@kubernetes/client-node"
+        versions:
+          - "1.0.0"
     groups:
       production-dependencies:
         dependency-type: production


### PR DESCRIPTION
## Description

@kubernetes/client-node created a release that breaks our ability to generate classes from CRDs. It also breaks CI. The release has no release notes either. Very strange. We definitely should skip this. 

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
