### PR TITLE
chore: remove redundant test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   test:
+    # Runs e2e tests and uni tests
     uses: "./.github/workflows/node.js.yml"
 
   release:
@@ -36,9 +37,6 @@ jobs:
 
       - name: Build
         run: npm run build
-
-      - name: Test
-        run: npm run test
 
       - name: Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   test:
-    # Runs e2e tests and uni tests
+    # Runs e2e tests and unit tests
     uses: "./.github/workflows/node.js.yml"
 
   release:


### PR DESCRIPTION
## Description

When taking on this issue I did not realize that this was already 95% accounted for. 

Here is how the composable action work in KFC:
- 1. `node.js.yml` runs the build and unit tests, before doing so, it pulls re-usable actions from `e2e.yaml` to run the e2e tests.
- 2.`release.yml` pulls re-usable actions from `node.js.yml` which run the e2e, then runs the unit tests before releasing. There was a redundant unit test in release.yml that was not necessary since it is already being unit tested when it pulls in `node.js.yml`. However, the `npm run build` is still required before publishing the package

## Related Issue

Fixes #423 

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
