### PR TITLE
chore: bump prod deps - not kubernetes/client-node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "http-status-codes": "2.3.0",
         "node-fetch": "2.7.0",
         "quicktype-core": "23.0.171",
-        "type-fest": "4.37.0",
-        "undici": "7.5.0",
+        "type-fest": "4.38.0",
+        "undici": "7.6.0",
         "yargs": "17.7.2"
       },
       "bin": {
@@ -12964,9 +12964,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.37.0.tgz",
-      "integrity": "sha512-S/5/0kFftkq27FPNye0XM1e2NsnoD/3FS+pBmbjmmtLT6I+i344KoOf7pvXreaFsDamWeaJX55nczA1m5PsBDg==",
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.38.0.tgz",
+      "integrity": "sha512-2dBz5D5ycHIoliLYLi0Q2V7KRaDlH0uWIvmk7TYlAg5slqwiPv1ezJdZm1QEM0xgk29oYWMCbIG7E6gHpvChlg==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -13003,9 +13003,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.5.0.tgz",
-      "integrity": "sha512-NFQG741e8mJ0fLQk90xKxFdaSM7z4+IQpAgsFI36bCDY9Z2+aXXZjVy2uUksMouWfMI9+w5ejOq5zYYTBCQJDQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.6.0.tgz",
+      "integrity": "sha512-gaFsbThjrDGvAaD670r81RZro/s6H2PVZF640Qn0p5kZK+/rim7/mmyfp2W7VB5vOMaFM8vuFBJUaMlaZTYHlA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "http-status-codes": "2.3.0",
     "node-fetch": "2.7.0",
     "quicktype-core": "23.0.171",
-    "type-fest": "4.37.0",
-    "undici": "7.5.0",
+    "type-fest": "4.38.0",
+    "undici": "7.6.0",
     "yargs": "17.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

PR #599 has our dependabot updates along with the kubernetes/client-node update which would break KFC. Since we cannot close a dependabot PR (or it we would lose future updates to those deps) we can unblock prod updates manually by updating the dependencies other than the kubernetes/client-node.

## Related Issue

Fixes #

<!-- or -->

Relates to #591 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
