### PR TITLE
fix: bump undici and typefest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "http-status-codes": "2.3.0",
         "node-fetch": "2.7.0",
         "quicktype-core": "23.0.171",
-        "type-fest": "4.38.0",
-        "undici": "7.6.0",
+        "type-fest": "^4.39.0",
+        "undici": "^7.7.0",
         "yargs": "17.7.2"
       },
       "bin": {
@@ -12964,9 +12964,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.38.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.38.0.tgz",
-      "integrity": "sha512-2dBz5D5ycHIoliLYLi0Q2V7KRaDlH0uWIvmk7TYlAg5slqwiPv1ezJdZm1QEM0xgk29oYWMCbIG7E6gHpvChlg==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.0.tgz",
+      "integrity": "sha512-w2IGJU1tIgcrepg9ZJ82d8UmItNQtOFJG0HCUE3SzMokKkTsruVDALl2fAdiEzJlfduoU+VyXJWIIUZ+6jV+nw==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -13003,9 +13003,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.6.0.tgz",
-      "integrity": "sha512-gaFsbThjrDGvAaD670r81RZro/s6H2PVZF640Qn0p5kZK+/rim7/mmyfp2W7VB5vOMaFM8vuFBJUaMlaZTYHlA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.7.0.tgz",
+      "integrity": "sha512-tZ6+5NBq4KH35rr46XJ2JPFKxfcBlYNaqLF/wyWIO9RMHqqU/gx/CLB1Y2qMcgB8lWw/bKHa7qzspqCN7mUHvA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "http-status-codes": "2.3.0",
     "node-fetch": "2.7.0",
     "quicktype-core": "23.0.171",
-    "type-fest": "4.38.0",
-    "undici": "7.6.0",
+    "type-fest": "^4.39.0",
+    "undici": "^7.7.0",
     "yargs": "17.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

When `@kubernetes/client-node` was released 21 days ago, it created breaking changes in KFC. Due to this, we cannot get our prod dependency updates from dependabot

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
