### PR TITLE
chore: ignore kubenertes/client-node@1.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     ignore:
       - dependency-name: "@kubernetes/client-node"
         versions:
-          - "1.0.0"
+          - "1.1.0"
     groups:
       production-dependencies:
         dependency-type: production

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "http-status-codes": "2.3.0",
         "node-fetch": "2.7.0",
         "quicktype-core": "23.0.171",
-        "type-fest": "^4.39.0",
+        "type-fest": "^4.39.1",
         "undici": "^7.7.0",
         "yargs": "17.7.2"
       },
@@ -12964,9 +12964,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.0.tgz",
-      "integrity": "sha512-w2IGJU1tIgcrepg9ZJ82d8UmItNQtOFJG0HCUE3SzMokKkTsruVDALl2fAdiEzJlfduoU+VyXJWIIUZ+6jV+nw==",
+      "version": "4.39.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.1.tgz",
+      "integrity": "sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "http-status-codes": "2.3.0",
     "node-fetch": "2.7.0",
     "quicktype-core": "23.0.171",
-    "type-fest": "^4.39.0",
+    "type-fest": "^4.39.1",
     "undici": "^7.7.0",
     "yargs": "17.7.2"
   },


### PR DESCRIPTION
## Description

We are blocked on upgrading `@kubernetes/client-node` due to #591. This is causing us to have to manually update prod dependencies. We need an ignore rule so this can still be automated while we get to #591 

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
