### PR TITLE
chore: more robust ignore rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     ignore:
       - dependency-name: "@kubernetes/client-node"
         versions:
-          - "1.1.0"
+          - "1.x"
     groups:
       production-dependencies:
         dependency-type: production


### PR DESCRIPTION
## Description

Based on the [docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#versions-ignore), we should be able to ignore all `1.x` releases of `@kubernetes/client-node` with this rule.

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
