### PR TITLE
fix: override generated endpoint class to correct type

### DIFF
--- a/src/kinds.test.ts
+++ b/src/kinds.test.ts
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2023-Present The Kubernetes Fluent Client Authors
 
 import { expect, test } from "@jest/globals";
-
 import { kind, modelToGroupVersionKind } from "./index";
 import { RegisterKind } from "./kinds";
 import { GroupVersionKind } from "./types";
@@ -118,6 +117,10 @@ const testCases = [
   {
     name: kind.VolumeAttachment,
     expected: { group: "storage.k8s.io", version: "v1", kind: "VolumeAttachment" },
+  },
+  {
+    name: kind.Endpoint,
+    expected: { group: "", version: "v1", kind: "Endpoints", plural: "endpoints" },
   },
 ];
 

--- a/src/kinds.ts
+++ b/src/kinds.ts
@@ -94,12 +94,14 @@ const gvkMap: Record<string, GroupVersionKind> = {
    *
    * @see {@link https://kubernetes.io/docs/concepts/services-networking/service/#endpoints}
    */
-  V1Endpoint: {
-    kind: "Endpoints",
-    version: "v1",
-    group: "",
-    plural: "endpoints",
-  },
+  // https://github.com/defenseunicorns/kubernetes-fluent-client/issues/618
+  // The endpoint generated type is not correct and is registered elsewhere
+  // V1Endpoint: {
+  //   kind: "Endpoints",
+  //   version: "v1",
+  //   group: "",
+  //   plural: "endpoints",
+  // },
 
   /**
    * Represents a K8s LimitRange resource.

--- a/src/kinds.ts
+++ b/src/kinds.ts
@@ -96,6 +96,7 @@ const gvkMap: Record<string, GroupVersionKind> = {
    */
   // https://github.com/defenseunicorns/kubernetes-fluent-client/issues/618
   // The endpoint generated type is not correct and is registered elsewhere
+  // Keep this commented out until the generated type is fixed in the upstream
   // V1Endpoint: {
   //   kind: "Endpoints",
   //   version: "v1",

--- a/src/upstream.ts
+++ b/src/upstream.ts
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2023-Present The Kubernetes Fluent Client Authors
 
 /** a is a collection of K8s types to be used within an action: `When(a.Configmap)` */
+import { V1Endpoint, V1ObjectMeta } from "@kubernetes/client-node";
+import { RegisterKind } from "./kinds";
 export {
   CoreV1Event as CoreEvent,
   EventsV1Event as Event,
@@ -49,7 +51,37 @@ export {
   V1TokenReview as TokenReview,
   V1ValidatingWebhookConfiguration as ValidatingWebhookConfiguration,
   V1VolumeAttachment as VolumeAttachment,
-  V1Endpoint as Endpoint,
+  // V1Endpoint as Endpoint,
 } from "@kubernetes/client-node";
 
 export { GenericKind } from "./types";
+
+export class Endpoint {
+  /**
+   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+   */
+  apiVersion: string = "v1";
+  /**
+   * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+   */
+  kind: string = "Endpoint";
+
+  metadata?: V1ObjectMeta;
+
+  /**
+   * The generated type only contains a single subnet, should should be an array
+   * kubectl explain ep
+   */
+  subnets?: V1Endpoint[];
+
+  constructor(init?: Partial<Endpoint>) {
+    Object.assign(this, init);
+  }
+}
+
+RegisterKind(Endpoint, {
+  group: "",
+  version: "v1",
+  kind: "Endpoints",
+  plural: "endpoints",
+});

--- a/src/upstream.ts
+++ b/src/upstream.ts
@@ -70,7 +70,7 @@ export class Endpoint {
 
   /**
    * The generated type only contains a single subnet, should should be an array
-   * kubectl explain ep
+   * > kubectl explain ep # to see actual endpoint type
    */
   subnets?: V1Endpoint[];
 

--- a/src/upstream.ts
+++ b/src/upstream.ts
@@ -51,7 +51,7 @@ export {
   V1TokenReview as TokenReview,
   V1ValidatingWebhookConfiguration as ValidatingWebhookConfiguration,
   V1VolumeAttachment as VolumeAttachment,
-  // V1Endpoint as Endpoint,
+  // V1Endpoint as Endpoint, - keep this so we do not forget incase it is corrected
 } from "@kubernetes/client-node";
 
 export { GenericKind } from "./types";


### PR DESCRIPTION
## Description

The generated `Endpoint` from the upstream library where our types are consumed is incorrect. It has only a subset of fields making it difficult to assert on the shape of the object in Pepr. This PR adds the `apiVersion`, `metadata`, `kind`, and corrects the `subnet` field to be an array like in the real endpoint schema.

```plaintext
KIND:       Endpoints
VERSION:    v1

DESCRIPTION:
    Endpoints is a collection of endpoints that implement the actual service.
    Example:
    
    	 Name: "mysvc",
    	 Subsets: [
    	   {
    	     Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],
    	     Ports: [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]
    	   },
    	   {
    	     Addresses: [{"ip": "10.10.3.3"}],
    	     Ports: [{"name": "a", "port": 93}, {"name": "b", "port": 76}]
    	   },
    	]
    
FIELDS:
  apiVersion	<string>
    APIVersion defines the versioned schema of this representation of an object.
    Servers should convert recognized schemas to the latest internal value, and
    may reject unrecognized values. More info:
    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources

  kind	<string>
    Kind is a string value representing the REST resource this object
    represents. Servers may infer this from the endpoint the client submits
    requests to. Cannot be updated. In CamelCase. More info:
    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds

  metadata	<ObjectMeta>
    Standard object's metadata. More info:
    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

  subsets	<[]EndpointSubset>
    The set of all endpoints is the union of all subsets. Addresses are placed
    into subsets according to the IPs they share. A single address with multiple
    ports, some of which are ready and some of which are not (because they come
    from different containers) will result in the address being displayed in
    different subsets for the different ports. No address will appear in both
    Addresses and NotReadyAddresses in the same subset. Sets of addresses and
    ports that comprise a service.
```

## Related Issue

Fixes #618 

<!-- or -->

Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
