### PR TITLE
fix: fix ep

### DIFF
--- a/src/kinds.test.ts
+++ b/src/kinds.test.ts
@@ -119,7 +119,7 @@ const testCases = [
     expected: { group: "storage.k8s.io", version: "v1", kind: "VolumeAttachment" },
   },
   {
-    name: kind.Endpoint,
+    name: kind.Endpoints,
     expected: { group: "", version: "v1", kind: "Endpoints", plural: "endpoints" },
   },
 ];

--- a/src/kinds.ts
+++ b/src/kinds.ts
@@ -96,13 +96,12 @@ const gvkMap: Record<string, GroupVersionKind> = {
    */
   // https://github.com/defenseunicorns/kubernetes-fluent-client/issues/618
   // The endpoint generated type is not correct and is registered elsewhere
-  // Keep this commented out until the generated type is fixed in the upstream
-  // V1Endpoint: {
-  //   kind: "Endpoints",
-  //   version: "v1",
-  //   group: "",
-  //   plural: "endpoints",
-  // },
+  V1Endpoints: {
+    kind: "Endpoints",
+    version: "v1",
+    group: "",
+    plural: "endpoints",
+  },
 
   /**
    * Represents a K8s LimitRange resource.

--- a/src/upstream.ts
+++ b/src/upstream.ts
@@ -2,8 +2,6 @@
 // SPDX-FileCopyrightText: 2023-Present The Kubernetes Fluent Client Authors
 
 /** a is a collection of K8s types to be used within an action: `When(a.Configmap)` */
-import { V1Endpoint, V1ObjectMeta } from "@kubernetes/client-node";
-import { RegisterKind } from "./kinds";
 export {
   CoreV1Event as CoreEvent,
   EventsV1Event as Event,
@@ -51,37 +49,5 @@ export {
   V1TokenReview as TokenReview,
   V1ValidatingWebhookConfiguration as ValidatingWebhookConfiguration,
   V1VolumeAttachment as VolumeAttachment,
-  // V1Endpoint as Endpoint, - keep this so we do not forget incase it is corrected
+  V1Endpoints as Endpoints,
 } from "@kubernetes/client-node";
-
-export { GenericKind } from "./types";
-
-export class Endpoint {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-   */
-  apiVersion: string = "v1";
-  /**
-   * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-   */
-  kind: string = "Endpoint";
-
-  metadata?: V1ObjectMeta;
-
-  /**
-   * The generated type only contains a single subnet, should should be an array
-   * > kubectl explain ep # to see actual endpoint type
-   */
-  subnets?: V1Endpoint[];
-
-  constructor(init?: Partial<Endpoint>) {
-    Object.assign(this, init);
-  }
-}
-
-RegisterKind(Endpoint, {
-  group: "",
-  version: "v1",
-  kind: "Endpoints",
-  plural: "endpoints",
-});


### PR DESCRIPTION
## Description

We were exporting `Endpoint` instead of `Endpoints`, which is the correct for endpoints in kubernetes.

```yaml
> k explain ep | head -2
KIND:       Endpoints
VERSION:    v1

> k api-resources | egrep "endpoints"
endpoints                           ep           v1                                true         Endpoints
```

The endpoint type was incorrect and was missing fields
## Related Issue

Fixes #622
Fixes #620 

<!-- or -->

Relates to #620 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
