### PR TITLE
chore: e2e test for watch

### DIFF
--- a/e2e/main.e2e.test.ts
+++ b/e2e/main.e2e.test.ts
@@ -1,5 +1,5 @@
 import { kind, K8s, fetch, GenericClass, KubernetesObject } from "kubernetes-fluent-client";
-import { beforeAll, afterAll, jest, test, describe, expect } from "@jest/globals";
+import { beforeAll, jest, test, describe, expect } from "@jest/globals";
 import { Datastore, Kind as Backing } from "./datastore-v1alpha1";
 import { WebApp, Phase, Language, Theme } from "./webapp-v1alpha1";
 import { execSync } from "child_process";
@@ -11,14 +11,6 @@ const namespace = `e2e-tests`;
 const clusterName = "kfc-dev";
 
 describe("KFC e2e test", () => {
-  afterAll(async () => {
-    try {
-      execCommand(`k3d cluster delete ${clusterName}`);
-    } catch {
-      throw new Error("Failed to delete cluster");
-    }
-  });
-
   beforeAll(async () => {
     try {
       await K8s(kind.Namespace).Apply({ metadata: { name: namespace } },{force: true});

--- a/e2e/watch.e2e.test.ts
+++ b/e2e/watch.e2e.test.ts
@@ -1,0 +1,130 @@
+import {
+  GenericClass,
+  K8s,
+  kind,
+  KubernetesObject,
+} from "kubernetes-fluent-client";
+import { beforeAll, describe, expect, it, jest } from "@jest/globals";
+import { execSync } from "child_process";
+import { WatchPhase } from "../src/fluent/types";
+import { WatchEvent } from "../src";
+jest.unmock("@kubernetes/client-node");
+const namespace = `kfc-watch`;
+describe("watcher e2e", () => {
+  beforeAll(async () => {
+    try {
+      await K8s(kind.Namespace).Apply({ metadata: { name: namespace } }, {
+        force: true,
+      });
+      await K8s(kind.Pod).Apply(
+        {
+          metadata: { name: namespace, namespace, labels: { app: "nginx" } },
+          spec: { containers: [{ name: "nginx", image: "nginx" }] },
+        },
+        { force: true },
+      );
+      await waitForRunningStatusPhase(kind.Pod, {
+        metadata: { name: namespace, namespace },
+      });
+    } catch (e) {
+      expect(e).toBeUndefined();
+    }
+  }, 80000);
+
+  it("should watch named resources", (done) => {
+    const watcher = K8s(kind.Pod).InNamespace(namespace).Watch((po) => {
+      expect(po.metadata!.name).toBe(namespace);
+      watcher.close();
+      done();
+    });
+    watcher.start();
+  });
+
+  it("should call the event handler for each event", (done) => {
+    const watcher = K8s(kind.Pod).InNamespace(namespace).Watch((po, evt) => {
+      expect(po.metadata!.name).toBe(namespace);
+      expect(evt).toBe(WatchPhase.Added);
+      watcher.close();
+      done();
+    });
+    watcher.start();
+  });
+
+  it("should return the cache id", () => {
+    const watcher = K8s(kind.Pod).InNamespace(namespace).Watch((po) =>
+      console.log(po.metadata!.name)
+    );
+    expect(watcher.getCacheID()).toBeDefined();
+    watcher.close();
+  });
+
+  it("should handle the CONNECT event", (done) => {
+    const watcher = K8s(kind.Pod).InNamespace(namespace).Watch((po) => {
+      expect(po.metadata!.name).toBe(namespace);
+    });
+    watcher.start();
+    watcher.events.on(WatchEvent.CONNECT, (path) => {
+      expect(path).toBe("/api/v1/namespaces/kfc-watch/pods");
+    });
+    watcher.close();
+    done();
+  });
+
+  it("should handle the RECONNECT event", (done) => {
+    const watcher = K8s(kind.Pod).InNamespace(namespace).Watch((po) => {
+      expect(po.metadata!.name).toBe(namespace);
+    });
+    watcher.start();
+
+    watcher.events.on(WatchEvent.RECONNECT, (num) => {
+      expect(num).toBe(1);
+    });
+    execSync(`k3d cluster stop kfc-dev`, { stdio: "inherit" });
+    execSync(`k3d cluster start kfc-dev`, { stdio: "inherit" });
+    watcher.close();
+    done();
+  });
+
+  it("should handle the DATA event", (done) => {
+    const watcher = K8s(kind.Pod).InNamespace(namespace).Watch((po) => {
+      expect(po.metadata!.name).toBe(namespace);
+    });
+    watcher.start();
+
+    watcher.events.on(WatchEvent.DATA, (po) => {
+      expect(po.metadata.name).toBe(namespace);
+    });
+    watcher.close();
+    done();
+  });
+});
+/**
+ * sleep for a given number of seconds
+ *
+ * @param seconds - number of seconds to sleep
+ * @returns Promise<void>
+ */
+export function sleep(seconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+}
+
+/**
+ * Wait for the status phase to be Running
+ *
+ * @param k - GenericClass
+ * @param o - KubernetesObject
+ * @returns Promise<void>
+ */
+export async function waitForRunningStatusPhase(
+  k: GenericClass,
+  o: KubernetesObject,
+): Promise<void> {
+  const object = await K8s(k)
+    .InNamespace(o.metadata?.namespace || "")
+    .Get(o.metadata?.name || "");
+
+  if (object.status?.phase !== "Running") {
+    await sleep(2);
+    return waitForRunningStatusPhase(k, o);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
     "target": "ES2022",
     "useUnknownInCatchVariables": false
   },
-  "include": ["src/**/*.ts", "e2e/**/*.ts"],
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
     "target": "ES2022",
     "useUnknownInCatchVariables": false
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "e2e/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Description

In support of https://github.com/defenseunicorns/kubernetes-fluent-client/issues/591, this is a e2e test for watch

## Related Issue

Fixes #680 

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
