### PR TITLE
fix: handle eslint exclusions on `e2e/`  when `format:check` runs

### DIFF
--- a/e2e/main.e2e.test.ts
+++ b/e2e/main.e2e.test.ts
@@ -2,13 +2,11 @@ import { kind, K8s, fetch, GenericClass, KubernetesObject } from "kubernetes-flu
 import { beforeAll, jest, test, describe, expect } from "@jest/globals";
 import { Datastore, Kind as Backing } from "./datastore-v1alpha1";
 import { WebApp, Phase, Language, Theme } from "./webapp-v1alpha1";
-import { execSync } from "child_process";
 import { V1APIGroup } from "@kubernetes/client-node";
 import { beforeEach } from "node:test";
 
 jest.unmock("@kubernetes/client-node");
 const namespace = `e2e-tests`;
-const clusterName = "kfc-dev";
 
 describe("KFC e2e test", () => {
   beforeAll(async () => {
@@ -447,14 +445,4 @@ const createCR = async (
   } catch (e) {
     expect(e).toBeUndefined();
   }
-};
-
-/**
- * Execute a command
- * 
- * @param cmd - string
- * @returns Buffer
- */
-const execCommand = (cmd: string): Buffer => {
-    return execSync(cmd, { stdio: "inherit" });
 };

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "lib": ["ES2022"],
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "strict": true,
+    "target": "ES2022",
+    "useUnknownInCatchVariables": false
+  },
+  "include": ["./**/*.e2e.test.ts"],
+  "exclude": ["node_modules", "dist", "**/crds/**"]
+}

--- a/e2e/watch.e2e.test.ts
+++ b/e2e/watch.e2e.test.ts
@@ -126,7 +126,7 @@ describe("watcher e2e", () => {
     watcher.start();
 
     watcher.events.on(WatchEvent.GIVE_UP, (err) => {
-      expect(err).toBeDefined;
+      expect(err).toBeDefined();
     });
     watcher.close();
     done();
@@ -147,7 +147,7 @@ describe("watcher e2e", () => {
     watcher.start();
 
     watcher.events.on(WatchEvent.GIVE_UP, (err) => {
-      expect(err).toBeDefined;
+      expect(err).toBeDefined();
     });
     watcher.close();
     done();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,13 @@ const compat = new FlatCompat({
 
 export default [
   {
-    ignores: ["**/node_modules", "**/dist", "**/__mocks__", ".github/workflows/matrix.js", "**/e2e/crds/**"],
+    ignores: [
+      "**/node_modules",
+      "**/dist",
+      "**/__mocks__",
+      ".github/workflows/matrix.js",
+      "**/e2e/crds/**",
+    ],
   },
   ...compat.extends(
     "eslint:recommended",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,7 @@ const compat = new FlatCompat({
 
 export default [
   {
-    ignores: ["**/node_modules", "**/dist", "**/__mocks__", ".github/workflows/matrix.js"],
+    ignores: ["**/node_modules", "**/dist", "**/__mocks__", ".github/workflows/matrix.js", "**/e2e/crds/**"],
   },
   ...compat.extends(
     "eslint:recommended",
@@ -38,7 +38,7 @@ export default [
       sourceType: "script",
 
       parserOptions: {
-        project: ["tsconfig.json"],
+        project: ["tsconfig.json", "./e2e/tsconfig.json"],
       },
     },
 

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "test:e2e:prep-image": "npm run build && npm pack && npm i kubernetes-fluent-client-0.0.0-development.tgz --no-save",
     "test:e2e:run": "npm run test:e2e:prep-cluster && npm run test:e2e:prep-crds && npm run test:e2e:prep-image && jest e2e --runInBand && npm run test:e2e:cleanup",
     "test:e2e:cleanup": "k3d cluster delete kfc-dev",
-    "format:check": "eslint src && prettier . --check",
-    "format:fix": "eslint --fix src && prettier . --write",
+    "format:check": "eslint src e2e && prettier . --check",
+    "format:fix": "eslint --fix src e2e && prettier . --write",
     "prepare": "if [ \"$NODE_ENV\" != 'production' ]; then husky; fi"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

#691 lints E2Es, but the configuration causes some issues when `npm run format:check` or during lint with the commit hooks. We'll see an error along the lines of:

```text
  0:0  error  Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser.
The file was not found in any of the provided project(s): e2e/webapp-v1alpha1.ts
```

Because we store `e2e` outside of `src`, our `tsconfig.json` file considers `e2e` tests as outside of scope. What we can do is add a tsconfig for the `e2e` tests and update the eslint config accordingly.

## Related Issue

Relates to #691 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
