### PR TITLE
chore: use correct request init for fetch

### DIFF
--- a/src/fluent/utils.test.ts
+++ b/src/fluent/utils.test.ts
@@ -3,7 +3,7 @@
 
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import * as fs from "fs";
-import { RequestInit } from "node-fetch";
+import { RequestInit } from "undici";
 import { fetch } from "../fetch";
 import { RegisterKind } from "../kinds";
 import { GenericClass } from "../types";


### PR DESCRIPTION
## Description

Our KFC Fetch function uses undici but the existing utils.test.ts is using node-fetch still. This has different attributes than the undici request init

## Related Issue

Fixes # hotfix

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
