### PR TITLE
chore: ensure e2e coverage for utils.ts

### DIFF
--- a/e2e/watch.e2e.test.ts
+++ b/e2e/watch.e2e.test.ts
@@ -57,14 +57,6 @@ describe("watcher e2e", () => {
     watcher.start();
   });
 
-  it("should return the cache id", () => {
-    const watcher = K8s(kind.Pod)
-      .InNamespace(namespace)
-      .Watch((po) => console.log(po.metadata!.name));
-    expect(watcher.getCacheID()).toBeDefined();
-    watcher.close();
-  });
-
   it("should handle the CONNECT event", (done) => {
     const watcher = K8s(kind.Pod)
       .InNamespace(namespace)

--- a/src/fluent/watch.test.ts
+++ b/src/fluent/watch.test.ts
@@ -160,13 +160,6 @@ describe("Watcher", () => {
     done();
   });
 
-  it("should return the cache id", () => {
-    watcher = K8s(kind.Pod).Watch(evtMock, {
-      resyncDelaySec: 1,
-    });
-    expect(watcher.getCacheID()).toEqual("d69b75a611");
-  });
-
   it("should handle the CONNECT event", done => {
     watcher = K8s(kind.Pod).Watch(evtMock, {
       resyncDelaySec: 1,

--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Kubernetes Fluent Client Authors
 
-import { createHash } from "crypto";
 import { EventEmitter } from "events";
 import { fetch } from "undici";
 import { fetch as wrappedFetch } from "../fetch";
@@ -169,23 +168,6 @@ export class Watcher<T extends GenericClass> {
 
     this.#streamCleanup();
     this.#abortController.abort();
-  }
-
-  /**
-   * Get a unique ID for the watch based on the model and filters.
-   * This is useful for caching the watch data or resource versions.
-   *
-   * @returns the watch CacheID
-   */
-  public getCacheID() {
-    // Build the URL, we don't care about the server URL or resourceVersion
-    const url = pathBuilder("https://ignore", this.#model, this.#filters, false);
-
-    // Hash and truncate the ID to 10 characters, cache the result
-    return createHash("sha224")
-      .update(url.pathname + url.search)
-      .digest("hex")
-      .substring(0, 10);
   }
 
   /**


### PR DESCRIPTION
## Description

This PR removes an unused function and ensures that the code in `utils.ts` is tested by our E2E suite. Here's how coverage was ensured:

```
describe("getToken", () => {
  // Called by getHeaders, used by Watcher.#watch, covered by `watch.e2e.test.ts`
});
describe("getHTTPSAgent", () => {
  // Called by k8sCfg, used in `watch.e2e.test.ts`, `main.e2e.test.ts`
});
describe("getHeaders", () => {
  // Called by K8s Config, covered by `watch.e2e.test.ts`, `main.e2e.test.ts` 
  // Called by watch.ts:#watch, covered by `watch.e2e.test.ts`, `main.e2e.test.ts`
});
describe("pathBuilder Function", () => {
  // Called by watch.ts:getCacheId,#buildURL, covered by `watch.e2e.test.ts`
  // NOTE: getCacheId is unused in production code. Remove it.
  // Called by k8sExec, covered by `watch.e2e.test.ts`, and `main.e2e.test.ts`
});

describe("k8sExec Function", () => {
  // Called by index.ts, covered by `main.e2e.test.ts`
});
```

## Related Issue

Fixes #679 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
