### PR TITLE
fix: display just the version when --version is passed

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ const require = createRequire(import.meta.url);
 const { version } = require("../package.json");
 
 void yargs(hideBin(process.argv))
-  .version("version", "Display version number", `kubernetes-fluent-client v${version}`)
+  .version("version", "Display version number", `${version}`)
   .alias("version", "V")
   .command(
     "crd [source] [directory]",


### PR DESCRIPTION
## Description

Related to #752 to handle CLI output

## Related Issue

hotfix for #752 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
