### PR TITLE
fix: unskip test

### DIFF
--- a/src/fluent/watch.test.ts
+++ b/src/fluent/watch.test.ts
@@ -280,7 +280,7 @@ describe("Watcher", () => {
     });
   });
 
-  it.skip("should handle the NETWORK_ERROR event", () => {
+  it("should handle the NETWORK_ERROR event", () => {
     mockClient
       .intercept({
         path: "/api/v1/pods",


### PR DESCRIPTION
## Description

add test back that was skipped over from the `@kubernetes/client-node` upgrade

## Related Issue

Fixes #767 

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
