### PR TITLE
fix: remove unneeded patch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Kubernetes Fluent Client Authors
 
-import "./patch.js";
-
 // Export kinds as a single object
 import * as kind from "./upstream.js";
 

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -1,8 +1,0 @@
-import { V1NetworkPolicyPeer } from "@kubernetes/client-node";
-
-declare module "@kubernetes/client-node" {
-  interface V1NetworkPolicyIngressRule {
-    from?: Array<V1NetworkPolicyPeer>;
-    // No need to redeclare other unchanged properties
-  }
-}


### PR DESCRIPTION
## Description

We were patching from of the ingress rule for the network policy definition. Since switching to the latest `@kubernetes/client-node` it is fixed

**DEBUGGING**

First deploy UDS Core to get a current ingress network policy
```bash
 k get netpol allow-keycloak-ingress-8080-keycloak-istio-admin-gateway -n keycloak -oyaml

```

```yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  annotations:
    uds/description: 8080-keycloak Istio admin gateway
  creationTimestamp: "2025-07-15T14:17:18Z"
  generation: 1
  labels:
    uds/generation: "1"
    uds/package: keycloak
  name: allow-keycloak-ingress-8080-keycloak-istio-admin-gateway
  namespace: keycloak
  ownerReferences:
  - apiVersion: uds.dev/v1alpha1
    kind: Package
    name: keycloak
    uid: 419388e1-9f4d-4411-9708-d41f5066c835
  resourceVersion: "1723"
  uid: 72dd1c29-9e96-479a-9752-9df32d3a6594
spec:
  ingress:
  - from:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: istio-admin-gateway
      podSelector:
        matchLabels:
          app: admin-ingressgateway
    ports:
    - port: 8080
      protocol: TCP
    - port: 15008
      protocol: TCP
  podSelector:
    matchLabels:
      app.kubernetes.io/name: keycloak
  policyTypes:
  - Ingress
```

Then make changes in KFC

```bash
npm run build && npm pack
```

Then Copy KFC into Pepr and build the image with the `Dockerfile.kfc`:

```bash
npm run build && docker buildx build --output type=docker --tag pepr:dev -f Dockerfile.kfc . 
```

Then go to uds-core and run slim dev

```bash
uds run slim-dev && k label ns pepr-system zarf.dev/agent=ignore && \
k set image deploy/pepr-uds-core-watcher -n pepr-system watcher=pepr:dev && \
k set image deploy/pepr-uds-core -n pepr-system server=pepr:dev

# As soon as the k3d uds cluster comes up import the image

k3d image import pepr:dev -c uds
```


Now finally get the ingress network policy again

```bash
>  k get netpol allow-keycloak-ingress-8080-keycloak-istio-admin-gateway -n keycloak -oyaml
```

```yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  annotations:
    uds/description: 8080-keycloak Istio admin gateway
  creationTimestamp: "2025-07-15T17:42:26Z"
  generation: 1
  labels:
    uds/generation: "1"
    uds/package: keycloak
  name: allow-keycloak-ingress-8080-keycloak-istio-admin-gateway
  namespace: keycloak
  ownerReferences:
  - apiVersion: uds.dev/v1alpha1
    kind: Package
    name: keycloak
    uid: d8c989fa-2e2c-4386-b67f-6cb403b67590
  resourceVersion: "1724"
  uid: 5d1d0444-b46a-4dbd-8285-0644ca4fc057
spec:
  ingress:
  - from:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: istio-admin-gateway
      podSelector:
        matchLabels:
          app: admin-ingressgateway
    ports:
    - port: 8080
      protocol: TCP
    - port: 15008
      protocol: TCP
  podSelector:
    matchLabels:
      app.kubernetes.io/name: keycloak
  policyTypes:
  - Ingress
```


## Related Issue

Fixes #397 (in Pepr)

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
