### PR TITLE
fix: revert patch due to errors in uds core

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Kubernetes Fluent Client Authors
 
+import "./patch.js";
+
 // Export kinds as a single object
 import * as kind from "./upstream.js";
 

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -1,0 +1,8 @@
+import { V1NetworkPolicyPeer } from "@kubernetes/client-node";
+
+declare module "@kubernetes/client-node" {
+  interface V1NetworkPolicyIngressRule {
+    from?: Array<V1NetworkPolicyPeer>;
+    // No need to redeclare other unchanged properties
+  }
+}


### PR DESCRIPTION
Reverts defenseunicorns/kubernetes-fluent-client#814

```json
{"level":50,"time":1753122086570,"pid":17,"hostname":"pepr-uds-core-watcher-7b7bbc5575-g5dqp","component":"operator.reconcilers","err":{"type":"Error","message":"failed to create typed patch object (keycloak/allow-keycloak-ingress-ambient-healthprobes; networking.k8s.io/v1, Kind=NetworkPolicy): .spec.ingress[0]._from: field not declared in schema","stack":"Error: failed to create typed patch object (keycloak/allow-keycloak-ingress-ambient-healthprobes; networking.k8s.io/v1, Kind=NetworkPolicy): .spec.ingress[0]._from: field not declared in schema\n    at networkPolicies (/app/module-276430c9fafa99cfeff5114db339e02e24948c43c21d97c32b80c54354aab4a4.js:1:76470)\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async packageReconciler (/app/module-276430c9fafa99cfeff5114db339e02e24948c43c21d97c32b80c54354aab4a4.js:1:77503)\n    at async Object.watchCallback (/app/node_modules/pepr/dist/lib.js:643:13)\n    at async Object.watchCallback [as callback] (/app/node_modules/pepr/dist/lib.js:2340:11)\n    at async #dequeue (/app/node_modules/pepr/dist/lib.js:2260:7)"},"msg":"Error configuring keycloak/keycloak, maxed out retries"}
```