### PR TITLE
feat: finalize in kfc

### DIFF
--- a/e2e/main.e2e.test.ts
+++ b/e2e/main.e2e.test.ts
@@ -43,6 +43,22 @@ describe("KFC e2e test", () => {
     await waitForRunningStatusPhase(kind.Pod, { metadata: { name: namespace, namespace } });
   });
 
+  it("Adds Finalizer to Deployment", async () => {
+    await K8s(kind.Deployment)
+      .InNamespace(namespace)
+      .Finalize("add", "example.com/finalizer", `${namespace}-scale`);
+    const deployment = await K8s(kind.Deployment).InNamespace(namespace).Get(`${namespace}-scale`);
+    expect(deployment.metadata?.finalizers).toContain("example.com/finalizer");
+  });
+
+  it("Removes Finalizer from Deployment", async () => {
+    await K8s(kind.Deployment)
+      .InNamespace(namespace)
+      .Finalize("remove", "example.com/finalizer", `${namespace}-scale`);
+    const deployment = await K8s(kind.Deployment).InNamespace(namespace).Get(`${namespace}-scale`);
+    expect(deployment.metadata?.finalizers ?? []).not.toContain("example.com/finalizer");
+  });
+
   it("Scales Deployment", async () => {
     const before = await K8s(kind.Deployment).InNamespace(namespace).Get(`${namespace}-scale`);
     expect(before.spec?.replicas).toBe(1);

--- a/src/fluent/index.test.ts
+++ b/src/fluent/index.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { V1APIGroup } from "@kubernetes/client-node";
 import { Operation } from "fast-json-patch";
-
-import { K8s } from "./index.js";
+import { KubernetesObject } from "@kubernetes/client-node";
+import { K8s, removeControllerFields, updateFinalizersOrSkip } from "./index.js";
 import { fetch } from "../fetch.js";
 import { Pod } from "../upstream.js";
 import { k8sCfg, k8sExec } from "./utils.js";
@@ -301,5 +301,102 @@ describe("Kube", () => {
     const result = await K8s(V1APIGroup).Raw("/api");
 
     expect(result).toEqual(mockResp);
+  });
+
+  it("should remove controller fields from the object", () => {
+    const obj = {
+      metadata: {
+        name: "test",
+        managedFields: [
+          {
+            manager: "kubectl",
+            operation: "Apply",
+            apiVersion: "v1",
+            time: new Date("2010-10-10T00:00:00Z"),
+            fieldsType: "FieldsV1",
+            fieldsV1: {
+              f: {
+                metadata: {
+                  f: {
+                    labels: {
+                      f: {
+                        "test-label": {},
+                      },
+                    },
+                  },
+                },
+                data: {
+                  f: {
+                    key: {},
+                  },
+                },
+              },
+            },
+          },
+        ],
+        uid: "abcde",
+        creationTimestamp: new Date("2023-10-01T00:00:00Z"),
+        generation: 1,
+        finalizers: ["test.finalizer"],
+      },
+    };
+
+    removeControllerFields(obj);
+
+    expect(obj.metadata).toEqual({
+      name: "test",
+    });
+  });
+
+  it("should update finalizers or skip if the finalizer is already present", async () => {
+    const fakePod1: KubernetesObject = {
+      metadata: {
+        name: "fake",
+        namespace: "default",
+        finalizers: ["test.finalizer1"],
+      },
+    };
+
+    const updatedFinalizers = await updateFinalizersOrSkip("add", "test.finalizer1", fakePod1);
+    // Finalizer is already there
+    expect(updatedFinalizers).toBe(null);
+
+    const fakePod2: KubernetesObject = {
+      metadata: {
+        name: "fake",
+        namespace: "default",
+        finalizers: ["test.finalizer1"],
+      },
+    };
+
+    const updatedFinalizers2 = await updateFinalizersOrSkip("add", "test.finalizer2", fakePod2);
+
+    expect(updatedFinalizers2).toContain("test.finalizer2");
+  });
+
+  it("should remove finalizers or skip if the finalizer is not present", async () => {
+    const fakePod1: KubernetesObject = {
+      metadata: {
+        name: "fake",
+        namespace: "default",
+        finalizers: [],
+      },
+    };
+
+    const updatedFinalizers = await updateFinalizersOrSkip("remove", "test.finalizer1", fakePod1);
+    // Finalizer is not there
+    expect(updatedFinalizers).toBe(null);
+
+    const fakePod2: KubernetesObject = {
+      metadata: {
+        name: "fake",
+        namespace: "default",
+        finalizers: ["test.finalizer"],
+      },
+    };
+
+    const updatedFinalizers2 = await updateFinalizersOrSkip("remove", "test.finalizer", fakePod2);
+
+    expect(updatedFinalizers2).toStrictEqual([]);
   });
 });

--- a/src/fluent/index.test.ts
+++ b/src/fluent/index.test.ts
@@ -348,7 +348,7 @@ describe("Kube", () => {
     });
   });
 
-  it("should update finalizers or skip if the finalizer is already present", async () => {
+  it("should skip 'add' if the finalizer is already present", async () => {
     const fakePod1: KubernetesObject = {
       metadata: {
         name: "fake",
@@ -360,7 +360,9 @@ describe("Kube", () => {
     const updatedFinalizers = await updateFinalizersOrSkip("add", "test.finalizer1", fakePod1);
     // Finalizer is already there
     expect(updatedFinalizers).toBe(null);
+  });
 
+  it("should add if the finalizer is not present", async () => {
     const fakePod2: KubernetesObject = {
       metadata: {
         name: "fake",
@@ -374,7 +376,7 @@ describe("Kube", () => {
     expect(updatedFinalizers2).toContain("test.finalizer2");
   });
 
-  it("should remove finalizers or skip if the finalizer is not present", async () => {
+  it("should skip 'remove' if the finalizer is not present", async () => {
     const fakePod1: KubernetesObject = {
       metadata: {
         name: "fake",
@@ -386,8 +388,10 @@ describe("Kube", () => {
     const updatedFinalizers = await updateFinalizersOrSkip("remove", "test.finalizer1", fakePod1);
     // Finalizer is not there
     expect(updatedFinalizers).toBe(null);
+  });
 
-    const fakePod2: KubernetesObject = {
+  it("should remove finalizers if they are present", async () => {
+    const fakePod: KubernetesObject = {
       metadata: {
         name: "fake",
         namespace: "default",
@@ -395,8 +399,8 @@ describe("Kube", () => {
       },
     };
 
-    const updatedFinalizers2 = await updateFinalizersOrSkip("remove", "test.finalizer", fakePod2);
+    const updatedFinalizers = await updateFinalizersOrSkip("remove", "test.finalizer", fakePod);
 
-    expect(updatedFinalizers2).toStrictEqual([]);
+    expect(updatedFinalizers).toStrictEqual([]);
   });
 });

--- a/src/fluent/index.test.ts
+++ b/src/fluent/index.test.ts
@@ -349,7 +349,7 @@ describe("Kube", () => {
   });
 
   it("should skip 'add' if the finalizer is already present", async () => {
-    const fakePod1: KubernetesObject = {
+    const fakePod: KubernetesObject = {
       metadata: {
         name: "fake",
         namespace: "default",
@@ -357,13 +357,13 @@ describe("Kube", () => {
       },
     };
 
-    const updatedFinalizers = await updateFinalizersOrSkip("add", "test.finalizer1", fakePod1);
+    const updatedFinalizers = await updateFinalizersOrSkip("add", "test.finalizer1", fakePod);
     // Finalizer is already there
     expect(updatedFinalizers).toBe(null);
   });
 
   it("should add if the finalizer is not present", async () => {
-    const fakePod2: KubernetesObject = {
+    const fakePod: KubernetesObject = {
       metadata: {
         name: "fake",
         namespace: "default",
@@ -371,13 +371,13 @@ describe("Kube", () => {
       },
     };
 
-    const updatedFinalizers2 = await updateFinalizersOrSkip("add", "test.finalizer2", fakePod2);
+    const updatedFinalizers = await updateFinalizersOrSkip("add", "test.finalizer2", fakePod);
 
-    expect(updatedFinalizers2).toContain("test.finalizer2");
+    expect(updatedFinalizers).toContain("test.finalizer2");
   });
 
   it("should skip 'remove' if the finalizer is not present", async () => {
-    const fakePod1: KubernetesObject = {
+    const fakePod: KubernetesObject = {
       metadata: {
         name: "fake",
         namespace: "default",
@@ -385,7 +385,7 @@ describe("Kube", () => {
       },
     };
 
-    const updatedFinalizers = await updateFinalizersOrSkip("remove", "test.finalizer1", fakePod1);
+    const updatedFinalizers = await updateFinalizersOrSkip("remove", "test.finalizer1", fakePod);
     // Finalizer is not there
     expect(updatedFinalizers).toBe(null);
   });

--- a/src/fluent/index.ts
+++ b/src/fluent/index.ts
@@ -458,20 +458,19 @@ export function updateFinalizersOrSkip(
   object: KubernetesObject,
 ): string[] | null {
   const current = object.metadata?.finalizers ?? [];
-
-  if (operation === "remove") {
-    if (!current.includes(finalizer)) {
-      return null; // no-op
-    }
-    return current.filter(f => f !== finalizer);
+  const isPresent = current.includes(finalizer);
+  
+  if ((operation === "remove" && !isPresent) || 
+      (operation === "add" && isPresent)) {
+    return null; // no-op
   }
-
-  if (operation === "add") {
-    if (current.includes(finalizer)) {
-      return null; // no-op
-    }
-    return [...current, finalizer];
+  
+  switch (operation) {
+    case "remove":
+      return current.filter(f => f !== finalizer);
+    case "add":
+      return [...current, finalizer];
+    default:
+      throw new Error(`Unsupported operation: ${operation}`);
   }
-
-  throw new Error(`Unsupported operation: ${operation}`);
 }

--- a/src/fluent/index.ts
+++ b/src/fluent/index.ts
@@ -459,12 +459,11 @@ export function updateFinalizersOrSkip(
 ): string[] | null {
   const current = object.metadata?.finalizers ?? [];
   const isPresent = current.includes(finalizer);
-  
-  if ((operation === "remove" && !isPresent) || 
-      (operation === "add" && isPresent)) {
+
+  if ((operation === "remove" && !isPresent) || (operation === "add" && isPresent)) {
     return null; // no-op
   }
-  
+
   switch (operation) {
     case "remove":
       return current.filter(f => f !== finalizer);

--- a/src/fluent/types.ts
+++ b/src/fluent/types.ts
@@ -44,6 +44,15 @@ export type GetFunction<K extends KubernetesObject> = {
 
 export type K8sFilteredActions<T extends GenericClass, K extends KubernetesObject> = {
   /**
+   * Perform a server-side apply to add or remove a finalizer from the resource.
+   *
+   * @param operation - the operation to perform, either "add" or "remove"
+   * @param finalizer - the finalizer to add or remove
+   * @param name - the name of the resource to perform the operation
+   * @returns a promise that resolves when the operation is complete
+   */
+  Finalize: (operation: "add" | "remove", finalizer: string, name?: string) => Promise<void>;
+  /**
    * Proxy request to the Kubernetes API for the given resource.
    * This uses the `/proxy` subresource, usually for pods or services.
    *

--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -327,6 +327,7 @@ describe("readOrFetchCrd from Kubernetes cluster", () => {
       WithLabel: vi.fn(),
       InNamespace: vi.fn(),
       Proxy: vi.fn(),
+      Finalize: vi.fn(),
     };
 
     // Make circular references for WithField and WithLabel
@@ -376,6 +377,7 @@ describe("readOrFetchCrd from Kubernetes cluster", () => {
       InNamespace: vi.fn(),
       Proxy: vi.fn(),
       Scale: vi.fn(),
+      Finalize: vi.fn(),
     };
 
     // Make circular references for WithField and WithLabel
@@ -434,6 +436,7 @@ describe("readOrFetchCrd error handling", () => {
       InNamespace: vi.fn(),
       Proxy: vi.fn(),
       Scale: vi.fn(),
+      Finalize: vi.fn(),
     };
 
     // Make circular references for methods that return the fluent API
@@ -476,6 +479,7 @@ describe("readOrFetchCrd error handling", () => {
       WithLabel: vi.fn(),
       InNamespace: vi.fn(),
       Proxy: vi.fn(),
+      Finalize: vi.fn(),
     };
 
     // Make circular references for method chaining


### PR DESCRIPTION
## Description

This PR adds the ability to add or remove finalizers from Kubernetes resources. Due to limitations in Kubernetes around JSON Patch and requiring a patch file Server Side Apply was the best option to ensure we are able to both and remove without needing a patch file. 

Due to the nature of Server Side Apply we first fetch the resource and then Apply the new state of the resource with the updated finalizers

## Related Issue

Fixes #807 

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
