### PR TITLE
chore: ts-node command does not work - use tsx

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Please follow the coding conventions and style used in the project. Use ESLint a
 ### Running Development Version Locally
 
 1. Run `npm run build` to build the package.
-2. For CLI, you can run `npx ts-node src/cli.ts`.
+2. For CLI, you can run `npx tsx src/cli.ts`.
 3. To consume the package in another project, you can run `npm pack` to generate the `kubernetes-fluent-client-0.0.0-development.tgz`, then you can install with `npm i kubernetes-fluent-client-0.0.0-development.tgz --no-save`.
 
 > [!TIP]


### PR DESCRIPTION
## Description

ts-node command does not work to run the cli, we need to use tsx

```bash
> npx ts-node src/cli.ts      
Error: Cannot find module '/Users/cmwylie19/kubernetes-fluent-client/src/generate.js' imported from /Users/cmwylie19/kubernetes-fluent-client/src/cli.ts
    at finalizeResolution (node:internal/modules/esm/resolve:274:11)
    at moduleResolve (node:internal/modules/esm/resolve:859:10)
    at defaultResolve (node:internal/modules/esm/resolve:983:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:799:12)
    at ModuleLoader.#cachedDefaultResolve (node:internal/modules/esm/loader:723:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:706:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)
    at ModuleJob.#link (node:internal/modules/esm/module_job:170:49) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///Users/cmwylie19/kubernetes-fluent-client/src/generate.js'
}

> npx tsx src/cli.ts --version
0.0.0-development
```
## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
