### PR TITLE
fix: override tar-fs vulnerable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11004,9 +11004,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
-      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "vitest": "^3.2.1"
   },
   "overrides": {
+    "tar-fs": "^3.1.1",
     "semantic-release@24.2.0": {
       "npm": {
         "glob": {


### PR DESCRIPTION
## Description

[VAT](https://vat.dso.mil/vat/image?imageName=opensource/defenseunicorns/pepr/controller&tag=v0.55.0-arm64&branch=master) has flagged the version of tar-fs being used by `@kubernetes/client-node` as highly vulnerable.


```bash
tar-fs-3.0.10
/app/node_modules/tar-fs
tar-fs provides filesystem bindings for tar-stream. Versions prior to 3.1.1, 2.1.3, and 1.16.5 are vulnerable to symlink validation bypass if the destination directory is predictable with a specific tarball. This issue has been patched in version 3.1.1, 2.1.4, and 1.16.6. A workaround involves using the ignore option on non files/directories.
```

We need to override the version of `tar-fs` to greater than `3.1.1` where it is fixed

**Before**
```bash
> npm ls tar-fs 
kubernetes-fluent-client@0.0.0-development /Users/cmwylie19/kubernetes-fluent-client
└─┬ @kubernetes/client-node@1.3.0
  └── tar-fs@3.0.9
```

**After** 

```bash
> npm ls tar-fs 
kubernetes-fluent-client@0.0.0-development /Users/cmwylie19/kubernetes-fluent-client
└─┬ @kubernetes/client-node@1.3.0
  └── tar-fs@3.1.1
  ```
## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
