### PR TITLE
chore: trusted publishing for npmjs and github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read # for checkout
+  id-token: write # Required for OIDC
 
 jobs:
   test:


### PR DESCRIPTION
## Description

npm classic tokens are revoked, session-based auth and CLI token management now available and now requires [trusted publishing](https://docs.npmjs.com/trusted-publishers), this means that authentication is gained through OIDC. In order to allow the workflow to do this we need to allow [`id-token: write`](https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow) perms.

[Background.](https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/)

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
