### PR TITLE
fix: use timeouts

### DIFF
--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -245,8 +245,8 @@ export class Watcher<T extends GenericClass> {
     removedItems?: Map<string, InstanceType<T>>,
     retryCount = 0,
   ): Promise<void> => {
-    const maxRetries = 3;
-    const maxPages = 1000; // Safeguard against infinite pagination
+    const maxRetries = 5;
+    const maxPages = 10;
 
     try {
       const { opts, serverUrl } = await this.#buildURL(false, undefined, continueToken);


### PR DESCRIPTION
## Description

When the KAS returns a 429 wait for the duration of the retry-after period and retry the list.

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
