### PR TITLE
fix: decouple list from watch

### DIFF
--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -415,10 +415,14 @@ export class Watcher<T extends GenericClass> {
    * Watch for changes to the resource.
    */
   #watch = async () => {
+    // Start with a list operation, but don't let it block the watch stream
     try {
-      // Start with a list operation
       await this.#list();
+    } catch (listError) {
+      this.#events.emit(WatchEvent.LIST_ERROR, listError);
+    }
 
+    try {
       // Build the URL and request options
       const { opts, serverUrl } = await this.#buildURL(true, this.#resourceVersion);
 


### PR DESCRIPTION
## Description

Decouple failures in the list from the watch call.

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
