### PR TITLE
fix: cache items after callback succeeds to prevent permanent loss

### DIFF
--- a/src/fluent/watch.test.ts
+++ b/src/fluent/watch.test.ts
@@ -750,10 +750,8 @@ function mockListAndWatch(ns: string, items: kind.Pod[], rv: string, watchError?
     .intercept({ path: `/api/v1/namespaces/${ns}/pods`, method: "GET" })
     .reply(200, { kind: "PodList", apiVersion: "v1", metadata: { resourceVersion: rv }, items });
 
-  const watchIntercept = mockClient.intercept({
-    path: new RegExp(`/api/v1/namespaces/${ns}/pods\\?watch=true`),
-    method: "GET",
-  });
+  const watchPath = `/api/v1/namespaces/${ns}/pods?watch=true&resourceVersion=${rv}`;
+  const watchIntercept = mockClient.intercept({ path: watchPath, method: "GET" });
   if (watchError) watchIntercept.replyWithError(watchError);
   else watchIntercept.reply(200);
 }
@@ -773,14 +771,25 @@ function startAndWaitFor(
   timeoutMs = 10000,
 ) {
   return new Promise<void>((resolve, reject) => {
-    const t = setTimeout(() => reject(new Error(`Timed out waiting for ${event}`)), timeoutMs);
-    w.events.on(event, () => {
+    const cleanup = () => {
+      clearTimeout(t);
+      w.events.removeListener(event, handler);
+    };
+    const t = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for ${event}`));
+    }, timeoutMs);
+    const handler = () => {
       if (!predicate || predicate()) {
-        clearTimeout(t);
+        cleanup();
         resolve();
       }
+    };
+    w.events.on(event, handler);
+    w.start().catch(err => {
+      cleanup();
+      reject(err);
     });
-    w.start().catch(reject);
   });
 }
 

--- a/src/fluent/watch.test.ts
+++ b/src/fluent/watch.test.ts
@@ -579,22 +579,21 @@ describe("Watcher", () => {
 
   it.each([
     {
-      name: "callback failure during list",
+      name: "callback-failure-during-list",
       setup: (ns: string) => {
         for (let i = 0; i < 5; i++)
           mockListAndWatch(ns, [createMockPod("p", "1", "uid")], String(50 + i));
       },
-      callback: (() => {
+      makeCallback: () => {
         let n = 0;
         return async () => {
           if (++n <= 2) throw new Error("callback fails");
         };
-      })(),
+      },
     },
     {
-      name: "relist timer HTTP 500",
+      name: "relist-timer-HTTP-500",
       setup: (ns: string) => {
-        // First list succeeds, subsequent lists return 500
         mockListAndWatch(ns, [], "50");
         for (let i = 0; i < 5; i++) {
           mockClient
@@ -608,10 +607,11 @@ describe("Watcher", () => {
             .reply(200);
         }
       },
-      callback: vi.fn(),
+      makeCallback: () => vi.fn(),
     },
-  ])("should trigger faster resync on $name", async ({ setup, callback }) => {
-    const namespace = `resync-${Date.now()}`;
+  ])("should trigger faster resync on $name", async ({ name, setup, makeCallback }) => {
+    const namespace = `resync-${name}`;
+    const callback = makeCallback();
     setup(namespace);
 
     watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {

--- a/src/fluent/watch.test.ts
+++ b/src/fluent/watch.test.ts
@@ -562,7 +562,7 @@ describe("Watcher", () => {
     expect(callCount).toBeGreaterThanOrEqual(2);
   });
 
-  it("should cache items after successful callback", async () => {
+  it("should skip re-processing cached items with unchanged resource version on relist", async () => {
     const namespace = "cache-success-test";
 
     // First list: item exists
@@ -614,10 +614,10 @@ describe("Watcher", () => {
     });
 
     await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        clearTimeout(timeout);
-        resolve();
-      }, 1500);
+      const timeout = setTimeout(
+        () => reject(new Error("Timed out waiting for second relist")),
+        5000,
+      );
 
       let listCount = 0;
       watcher.events.on(WatchEvent.LIST, () => {
@@ -638,7 +638,7 @@ describe("Watcher", () => {
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
-  it("should return false from list when 429 exhausts retries", async () => {
+  it("should emit LIST_ERROR and skip callback when 429 exhausts retries", async () => {
     const namespace = "list-429-test";
 
     // List returns 429 with retry-after header
@@ -1125,7 +1125,11 @@ describe("Watcher", () => {
  * @param uid The UID of the pod
  * @returns A mock pod object
  */
-function createMockPod(name: string, resourceVersion: string, uid = "random-uid"): kind.Pod {
+function createMockPod(
+  name: string,
+  resourceVersion: string,
+  uid: string = crypto.randomUUID(),
+): kind.Pod {
   return {
     kind: "Pod",
     apiVersion: "v1",

--- a/src/fluent/watch.test.ts
+++ b/src/fluent/watch.test.ts
@@ -786,6 +786,131 @@ describe("Watcher", () => {
     expect(deleteCallCount).toBeGreaterThanOrEqual(2);
   });
 
+  it("should not run concurrent list operations", async () => {
+    const namespace = "concurrent-list-test";
+    let concurrentLists = 0;
+    let maxConcurrentLists = 0;
+
+    // Provide many list/watch interceptors for reconnect cycles
+    for (let i = 0; i < 10; i++) {
+      mockClient
+        .intercept({ path: `/api/v1/namespaces/${namespace}/pods`, method: "GET" })
+        .reply(200, {
+          kind: "PodList",
+          apiVersion: "v1",
+          metadata: { resourceVersion: String(50 + i) },
+          items: [createMockPod("slow-pod", "1", "slow-pod-uid")],
+        });
+
+      mockClient
+        .intercept({
+          path: new RegExp(`/api/v1/namespaces/${namespace}/pods\\?watch=true`),
+          method: "GET",
+        })
+        .reply(200);
+    }
+
+    const callback = vi
+      .fn<(pod: kind.Pod, phase: WatchPhase) => Promise<void>>()
+      .mockImplementation(async () => {
+        concurrentLists++;
+        maxConcurrentLists = Math.max(maxConcurrentLists, concurrentLists);
+        // Slow callback to widen the race window
+        await new Promise(r => setTimeout(r, 100));
+        concurrentLists--;
+      });
+
+    watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
+      resyncDelaySec: 5,
+      lastSeenLimitSeconds: 30,
+      relistIntervalSec: 0.05, // Very short relist interval to trigger overlap attempts
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("Timed out waiting for relist cycles")),
+        5000,
+      );
+
+      let listCount = 0;
+      watcher.events.on(WatchEvent.LIST, () => {
+        listCount++;
+        if (listCount >= 3) {
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+
+      watcher.start().catch(reject);
+    });
+
+    // At no point should more than one list operation have been processing concurrently
+    expect(maxConcurrentLists).toBeLessThanOrEqual(1);
+  });
+
+  it("should trigger faster resync when relist timer list fails", async () => {
+    const namespace = "relist-fail-resync-test";
+
+    // First list (from #watch) succeeds
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods`,
+        method: "GET",
+      })
+      .reply(200, {
+        kind: "PodList",
+        apiVersion: "v1",
+        metadata: { resourceVersion: "50" },
+        items: [],
+      });
+
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=50`,
+        method: "GET",
+      })
+      .reply(200);
+
+    // Relist (from timer) fails with 500
+    for (let i = 0; i < 5; i++) {
+      mockClient
+        .intercept({
+          path: `/api/v1/namespaces/${namespace}/pods`,
+          method: "GET",
+        })
+        .reply(500, { message: "Internal Server Error" });
+
+      mockClient
+        .intercept({
+          path: new RegExp(`/api/v1/namespaces/${namespace}/pods\\?watch=true`),
+          method: "GET",
+        })
+        .reply(200);
+    }
+
+    const callback = vi.fn();
+
+    watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
+      resyncDelaySec: 0.01,
+      lastSeenLimitSeconds: 0.01,
+      relistIntervalSec: 0.05,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("Timed out waiting for reconnect after relist failure")),
+        5000,
+      );
+
+      watcher.events.on(WatchEvent.RECONNECT, () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+
+      watcher.start().catch(reject);
+    });
+  });
+
   it("should trigger reconnect after non-OK watch response", async () => {
     const namespace = "reconnect-test";
 

--- a/src/fluent/watch.test.ts
+++ b/src/fluent/watch.test.ts
@@ -830,6 +830,61 @@ describe("Watcher", () => {
     expect(deleteCallCount).toBeGreaterThanOrEqual(2);
   });
 
+  it("should trigger faster resync when callback fails during list", async () => {
+    const namespace = "callback-fail-resync-test";
+
+    // Provide list/watch interceptors for multiple reconnect cycles
+    for (let i = 0; i < 5; i++) {
+      mockClient
+        .intercept({ path: `/api/v1/namespaces/${namespace}/pods`, method: "GET" })
+        .reply(200, {
+          kind: "PodList",
+          apiVersion: "v1",
+          metadata: { resourceVersion: String(50 + i) },
+          items: [createMockPod("fail-pod", "1", "fail-resync-uid")],
+        });
+
+      mockClient
+        .intercept({
+          path: new RegExp(`/api/v1/namespaces/${namespace}/pods\\?watch=true`),
+          method: "GET",
+        })
+        .reply(200);
+    }
+
+    let callCount = 0;
+    const callback = vi
+      .fn<(pod: kind.Pod, phase: WatchPhase) => Promise<void>>()
+      .mockImplementation(async () => {
+        callCount++;
+        if (callCount <= 2) {
+          throw new Error("callback fails");
+        }
+      });
+
+    watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
+      resyncDelaySec: 0.01,
+      lastSeenLimitSeconds: 0.01,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("Timed out waiting for resync after callback failure")),
+        10000,
+      );
+
+      watcher.events.on(WatchEvent.RECONNECT, () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+
+      watcher.start().catch(reject);
+    });
+
+    // A RECONNECT was triggered because the callback failure caused #list to return false
+    expect(callCount).toBeGreaterThanOrEqual(1);
+  });
+
   it("should not run concurrent list operations", async () => {
     const namespace = "concurrent-list-test";
     let concurrentLists = 0;

--- a/src/fluent/watch.test.ts
+++ b/src/fluent/watch.test.ts
@@ -412,10 +412,17 @@ describe("Watcher", () => {
 
   it("should not cache items or emit DATA when callback fails", async () => {
     const namespace = "callback-fail-test";
+    let callCount = 0;
 
     mockListAndWatch(namespace, [createMockPod("fail-pod", "1", "fail-pod-uid")], "50");
 
-    const callback = vi.fn().mockRejectedValue(new Error("callback failed"));
+    // Conditional throw: only the first call fails. If the item were incorrectly
+    // cached, it would not be retried and callCount would stay at 1. The retry
+    // test below verifies the second call succeeds on relist.
+    const callback = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) throw new Error("callback failed");
+    });
 
     watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
       resyncDelaySec: 5,
@@ -533,10 +540,14 @@ describe("Watcher", () => {
       lastSeenLimitSeconds: 60,
     });
 
+    const dataErrors: Error[] = [];
+    watcher.events.on(WatchEvent.DATA_ERROR, (err: Error) => dataErrors.push(err));
+
     await watcher.start();
 
     expect(callback).toHaveBeenCalledTimes(2);
     expect(processOrder).toEqual(["pod-a", "pod-b"]);
+    expect(dataErrors).toHaveLength(0);
   });
 
   it("should retry delete when delete callback fails", async () => {

--- a/src/fluent/watch.test.ts
+++ b/src/fluent/watch.test.ts
@@ -410,6 +410,382 @@ describe("Watcher", () => {
     expect(staleTokenReused).toBe(false);
   });
 
+  it("should not cache items when the callback fails", async () => {
+    const namespace = "callback-fail-test";
+    let callCount = 0;
+
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods`,
+        method: "GET",
+      })
+      .reply(200, {
+        kind: "PodList",
+        apiVersion: "v1",
+        metadata: { resourceVersion: "50" },
+        items: [createMockPod("fail-pod", "1", "fail-pod-uid")],
+      });
+
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=50`,
+        method: "GET",
+      })
+      .reply(200);
+
+    const callback = vi
+      .fn<(pod: kind.Pod, phase: WatchPhase) => Promise<void>>()
+      .mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error("callback failed");
+        }
+      });
+
+    watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
+      resyncDelaySec: 5,
+      lastSeenLimitSeconds: 30,
+    });
+
+    const dataErrors: Error[] = [];
+    watcher.events.on(WatchEvent.DATA_ERROR, (err: Error) => dataErrors.push(err));
+
+    await watcher.start();
+
+    // Callback was called once and failed
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(dataErrors.length).toBe(1);
+    expect(dataErrors[0].message).toBe("callback failed");
+  });
+
+  it("should retry failed items on next relist via reconnect", async () => {
+    const namespace = "relist-retry-test";
+    let callCount = 0;
+    const listResponse = (rv: string) => ({
+      kind: "PodList",
+      apiVersion: "v1",
+      metadata: { resourceVersion: rv },
+      items: [createMockPod("retry-pod", "1", "retry-pod-uid")],
+    });
+
+    // Provide multiple list/watch interceptors to handle reconnect cycles.
+    // The first list processes the item (callback fails), subsequent lists
+    // re-deliver it (callback succeeds) because the item was never cached.
+    for (let i = 0; i < 5; i++) {
+      mockClient
+        .intercept({ path: `/api/v1/namespaces/${namespace}/pods`, method: "GET" })
+        .reply(200, listResponse(String(50 + i)));
+
+      mockClient
+        .intercept({
+          path: new RegExp(`/api/v1/namespaces/${namespace}/pods\\?watch=true`),
+          method: "GET",
+        })
+        .replyWithError(new Error("stream error"));
+    }
+
+    const callback = vi
+      .fn<(pod: kind.Pod, phase: WatchPhase) => Promise<void>>()
+      .mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error("callback failed first time");
+        }
+      });
+
+    watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
+      resyncDelaySec: 0.01,
+      lastSeenLimitSeconds: 0.01,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("Timed out waiting for retry callback")),
+        10000,
+      );
+
+      watcher.events.on(WatchEvent.LIST, () => {
+        if (callCount >= 2) {
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+
+      watcher.start().catch(reject);
+    });
+
+    // Callback was called at least twice: first failed (item not cached), then retried on reconnect
+    expect(callCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it("should cache items after successful callback", async () => {
+    const namespace = "cache-success-test";
+
+    // First list: item exists
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods`,
+        method: "GET",
+      })
+      .reply(200, {
+        kind: "PodList",
+        apiVersion: "v1",
+        metadata: { resourceVersion: "50" },
+        items: [createMockPod("cached-pod", "1", "cached-pod-uid")],
+      });
+
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=50`,
+        method: "GET",
+      })
+      .reply(200);
+
+    // Second list (relist): same item at same resourceVersion
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods`,
+        method: "GET",
+      })
+      .reply(200, {
+        kind: "PodList",
+        apiVersion: "v1",
+        metadata: { resourceVersion: "51" },
+        items: [createMockPod("cached-pod", "1", "cached-pod-uid")],
+      });
+
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=51`,
+        method: "GET",
+      })
+      .reply(200);
+
+    const callback = vi.fn<(pod: kind.Pod, phase: WatchPhase) => Promise<void>>();
+
+    watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
+      resyncDelaySec: 5,
+      lastSeenLimitSeconds: 30,
+      relistIntervalSec: 0.1,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        clearTimeout(timeout);
+        resolve();
+      }, 1500);
+
+      let listCount = 0;
+      watcher.events.on(WatchEvent.LIST, () => {
+        listCount++;
+        if (listCount >= 2) {
+          // Give a brief moment for processing, then resolve
+          setTimeout(() => {
+            clearTimeout(timeout);
+            resolve();
+          }, 100);
+        }
+      });
+
+      watcher.start().catch(reject);
+    });
+
+    // Callback should only be called once (first list adds it, second list sees same RV and skips)
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("should return false from list when 429 exhausts retries", async () => {
+    const namespace = "list-429-test";
+
+    // List returns 429 with retry-after header
+    for (let i = 0; i <= 5; i++) {
+      mockClient
+        .intercept({
+          path: `/api/v1/namespaces/${namespace}/pods`,
+          method: "GET",
+        })
+        .reply(429, { message: "Too Many Requests" }, { headers: { "retry-after": "0" } });
+    }
+
+    // Watch mock (may not be reached)
+    mockClient
+      .intercept({
+        path: new RegExp(`/api/v1/namespaces/${namespace}/pods\\?watch=true`),
+        method: "GET",
+      })
+      .reply(200);
+
+    const listErrors: Error[] = [];
+    const callback = vi.fn();
+
+    watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
+      resyncDelaySec: 60,
+      lastSeenLimitSeconds: 60,
+    });
+
+    watcher.events.on(WatchEvent.LIST_ERROR, (err: Error) => listErrors.push(err));
+
+    await watcher.start();
+
+    // LIST_ERROR should have been emitted
+    expect(listErrors.length).toBeGreaterThan(0);
+    // Callback should not have been called (list failed, no items processed)
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("should await process calls during list operations", async () => {
+    const namespace = "await-process-test";
+    const processOrder: string[] = [];
+
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods`,
+        method: "GET",
+      })
+      .reply(200, {
+        kind: "PodList",
+        apiVersion: "v1",
+        metadata: { resourceVersion: "50" },
+        items: [createMockPod("pod-a", "1", "uid-a"), createMockPod("pod-b", "1", "uid-b")],
+      });
+
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=50`,
+        method: "GET",
+      })
+      .reply(200);
+
+    const callback = vi
+      .fn<(pod: kind.Pod, phase: WatchPhase) => Promise<void>>()
+      .mockImplementation(async pod => {
+        // Simulate async work
+        await new Promise(r => setTimeout(r, 10));
+        processOrder.push(pod.metadata!.name!);
+      });
+
+    watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
+      resyncDelaySec: 60,
+      lastSeenLimitSeconds: 60,
+    });
+
+    const dataErrors: Error[] = [];
+    watcher.events.on(WatchEvent.DATA_ERROR, (err: Error) => dataErrors.push(err));
+
+    await watcher.start();
+
+    // Both callbacks completed (awaited, not fire-and-forget)
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(processOrder).toEqual(["pod-a", "pod-b"]);
+    // No unhandled errors
+    expect(dataErrors).toEqual([]);
+  });
+
+  it("should retry delete when delete callback fails", async () => {
+    const namespace = "delete-retry-test";
+    let deleteCallCount = 0;
+
+    // First list: item exists, callback succeeds (caches it)
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods`,
+        method: "GET",
+      })
+      .reply(200, {
+        kind: "PodList",
+        apiVersion: "v1",
+        metadata: { resourceVersion: "50" },
+        items: [createMockPod("del-pod", "1", "del-pod-uid")],
+      });
+
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=50`,
+        method: "GET",
+      })
+      .reply(200);
+
+    // Second list (relist): item is GONE, triggering delete. Callback fails.
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods`,
+        method: "GET",
+      })
+      .reply(200, {
+        kind: "PodList",
+        apiVersion: "v1",
+        metadata: { resourceVersion: "51" },
+        items: [], // item removed
+      });
+
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=51`,
+        method: "GET",
+      })
+      .reply(200);
+
+    // Third list (relist): item still GONE. Delete callback succeeds this time.
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods`,
+        method: "GET",
+      })
+      .reply(200, {
+        kind: "PodList",
+        apiVersion: "v1",
+        metadata: { resourceVersion: "52" },
+        items: [],
+      });
+
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=52`,
+        method: "GET",
+      })
+      .reply(200);
+
+    const callback = vi
+      .fn<(pod: kind.Pod, phase: WatchPhase) => Promise<void>>()
+      .mockImplementation(async (_pod, phase) => {
+        if (phase === WatchPhase.Deleted) {
+          deleteCallCount++;
+          if (deleteCallCount === 1) {
+            throw new Error("delete callback failed");
+          }
+        }
+      });
+
+    watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
+      resyncDelaySec: 5,
+      lastSeenLimitSeconds: 30,
+      relistIntervalSec: 0.1,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("Timed out waiting for delete retry")),
+        5000,
+      );
+
+      let listCount = 0;
+      watcher.events.on(WatchEvent.LIST, () => {
+        listCount++;
+        if (listCount >= 3) {
+          setTimeout(() => {
+            clearTimeout(timeout);
+            resolve();
+          }, 200);
+        }
+      });
+
+      watcher.start().catch(reject);
+    });
+
+    // Delete callback was called at least twice (first failed, second succeeded)
+    expect(deleteCallCount).toBeGreaterThanOrEqual(2);
+  });
+
   it("should trigger reconnect after non-OK watch response", async () => {
     const namespace = "reconnect-test";
 
@@ -475,16 +851,17 @@ describe("Watcher", () => {
  *
  * @param name The name of the pod
  * @param resourceVersion The resource version of the pod
+ * @param uid The UID of the pod
  * @returns A mock pod object
  */
-function createMockPod(name: string, resourceVersion: string): kind.Pod {
+function createMockPod(name: string, resourceVersion: string, uid = "random-uid"): kind.Pod {
   return {
     kind: "Pod",
     apiVersion: "v1",
     metadata: {
       name: name,
       resourceVersion: resourceVersion,
-      uid: "random-uid",
+      uid,
     },
     spec: {
       containers: [

--- a/src/fluent/watch.test.ts
+++ b/src/fluent/watch.test.ts
@@ -513,6 +513,30 @@ describe("Watcher", () => {
     expect(callback).not.toHaveBeenCalled();
   });
 
+  it("should retry first-page 429 without being blocked by listInProgress guard", async () => {
+    const namespace = "list-429-retry-test";
+
+    // First attempt: 429 with retry-after
+    mockClient
+      .intercept({ path: `/api/v1/namespaces/${namespace}/pods`, method: "GET" })
+      .reply(429, { message: "Too Many Requests" }, { headers: { "retry-after": "0" } });
+
+    // Retry attempt: succeeds
+    mockListAndWatch(namespace, [createMockPod("retry-pod", "1", "retry-uid")], "50");
+
+    const callback = vi.fn();
+
+    watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
+      resyncDelaySec: 60,
+      lastSeenLimitSeconds: 60,
+    });
+
+    await watcher.start();
+
+    // The retry succeeded — callback was invoked for the item
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
   it("should await process calls during list operations", async () => {
     const namespace = "await-process-test";
     const processOrder: string[] = [];

--- a/src/fluent/watch.test.ts
+++ b/src/fluent/watch.test.ts
@@ -72,13 +72,6 @@ describe("Watcher", () => {
 
     mockClient = mockAgent.get("https://jest-test:8080");
 
-    // Setup MockAgent from undici
-    mockAgent = new MockAgent();
-    mockAgent.disableNetConnect();
-    setGlobalDispatcher(mockAgent);
-
-    mockClient = mockAgent.get("https://jest-test:8080");
-
     // Mock list operation
     mockClient
       .intercept({

--- a/src/fluent/watch.test.ts
+++ b/src/fluent/watch.test.ts
@@ -410,79 +410,12 @@ describe("Watcher", () => {
     expect(staleTokenReused).toBe(false);
   });
 
-  it("should not cache items when the callback fails", async () => {
+  it("should not cache items or emit DATA when callback fails", async () => {
     const namespace = "callback-fail-test";
-    let callCount = 0;
 
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods`,
-        method: "GET",
-      })
-      .reply(200, {
-        kind: "PodList",
-        apiVersion: "v1",
-        metadata: { resourceVersion: "50" },
-        items: [createMockPod("fail-pod", "1", "fail-pod-uid")],
-      });
+    mockListAndWatch(namespace, [createMockPod("fail-pod", "1", "fail-pod-uid")], "50");
 
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=50`,
-        method: "GET",
-      })
-      .reply(200);
-
-    const callback = vi
-      .fn<(pod: kind.Pod, phase: WatchPhase) => Promise<void>>()
-      .mockImplementation(async () => {
-        callCount++;
-        if (callCount === 1) {
-          throw new Error("callback failed");
-        }
-      });
-
-    watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
-      resyncDelaySec: 5,
-      lastSeenLimitSeconds: 30,
-    });
-
-    const dataErrors: Error[] = [];
-    watcher.events.on(WatchEvent.DATA_ERROR, (err: Error) => dataErrors.push(err));
-
-    await watcher.start();
-
-    // Callback was called once and failed
-    expect(callback).toHaveBeenCalledTimes(1);
-    expect(dataErrors.length).toBe(1);
-    expect(dataErrors[0].message).toBe("callback failed");
-  });
-
-  it("should not emit DATA when callback throws", async () => {
-    const namespace = "data-no-emit-test";
-
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods`,
-        method: "GET",
-      })
-      .reply(200, {
-        kind: "PodList",
-        apiVersion: "v1",
-        metadata: { resourceVersion: "50" },
-        items: [createMockPod("fail-pod", "1", "data-fail-uid")],
-      });
-
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=50`,
-        method: "GET",
-      })
-      .reply(200);
-
-    const callback = vi
-      .fn<(pod: kind.Pod, phase: WatchPhase) => Promise<void>>()
-      .mockRejectedValue(new Error("callback throws"));
+    const callback = vi.fn().mockRejectedValue(new Error("callback failed"));
 
     watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
       resyncDelaySec: 5,
@@ -496,116 +429,47 @@ describe("Watcher", () => {
 
     await watcher.start();
 
-    // DATA should NOT have been emitted since callback threw
-    expect(dataEvents.length).toBe(0);
-    // DATA_ERROR should have been emitted
-    expect(dataErrors.length).toBe(1);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(dataEvents).toHaveLength(0);
+    expect(dataErrors).toHaveLength(1);
+    expect(dataErrors[0].message).toBe("callback failed");
   });
 
   it("should retry failed items on next relist via reconnect", async () => {
     const namespace = "relist-retry-test";
     let callCount = 0;
-    const listResponse = (rv: string) => ({
-      kind: "PodList",
-      apiVersion: "v1",
-      metadata: { resourceVersion: rv },
-      items: [createMockPod("retry-pod", "1", "retry-pod-uid")],
-    });
 
-    // Provide multiple list/watch interceptors to handle reconnect cycles.
-    // The first list processes the item (callback fails), subsequent lists
-    // re-deliver it (callback succeeds) because the item was never cached.
     for (let i = 0; i < 5; i++) {
-      mockClient
-        .intercept({ path: `/api/v1/namespaces/${namespace}/pods`, method: "GET" })
-        .reply(200, listResponse(String(50 + i)));
-
-      mockClient
-        .intercept({
-          path: new RegExp(`/api/v1/namespaces/${namespace}/pods\\?watch=true`),
-          method: "GET",
-        })
-        .replyWithError(new Error("stream error"));
+      mockListAndWatch(
+        namespace,
+        [createMockPod("retry-pod", "1", "retry-pod-uid")],
+        String(50 + i),
+        new Error("stream error"),
+      );
     }
 
-    const callback = vi
-      .fn<(pod: kind.Pod, phase: WatchPhase) => Promise<void>>()
-      .mockImplementation(async () => {
-        callCount++;
-        if (callCount === 1) {
-          throw new Error("callback failed first time");
-        }
-      });
+    const callback = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) throw new Error("callback failed first time");
+    });
 
     watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
       resyncDelaySec: 0.01,
       lastSeenLimitSeconds: 0.01,
     });
 
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(
-        () => reject(new Error("Timed out waiting for retry callback")),
-        10000,
-      );
-
-      watcher.events.on(WatchEvent.LIST, () => {
-        if (callCount >= 2) {
-          clearTimeout(timeout);
-          resolve();
-        }
-      });
-
-      watcher.start().catch(reject);
-    });
-
-    // Callback was called at least twice: first failed (item not cached), then retried on reconnect
+    await startAndWaitFor(watcher, WatchEvent.LIST, () => callCount >= 2);
     expect(callCount).toBeGreaterThanOrEqual(2);
   });
 
   it("should skip re-processing cached items with unchanged resource version on relist", async () => {
     const namespace = "cache-success-test";
+    const uid = "cached-pod-uid";
 
-    // First list: item exists
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods`,
-        method: "GET",
-      })
-      .reply(200, {
-        kind: "PodList",
-        apiVersion: "v1",
-        metadata: { resourceVersion: "50" },
-        items: [createMockPod("cached-pod", "1", "cached-pod-uid")],
-      });
+    mockListAndWatch(namespace, [createMockPod("cached-pod", "1", uid)], "50");
+    mockListAndWatch(namespace, [createMockPod("cached-pod", "1", uid)], "51");
 
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=50`,
-        method: "GET",
-      })
-      .reply(200);
-
-    // Second list (relist): same item at same resourceVersion
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods`,
-        method: "GET",
-      })
-      .reply(200, {
-        kind: "PodList",
-        apiVersion: "v1",
-        metadata: { resourceVersion: "51" },
-        items: [createMockPod("cached-pod", "1", "cached-pod-uid")],
-      });
-
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=51`,
-        method: "GET",
-      })
-      .reply(200);
-
-    const callback = vi.fn<(pod: kind.Pod, phase: WatchPhase) => Promise<void>>();
+    const callback = vi.fn();
 
     watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
       resyncDelaySec: 5,
@@ -613,45 +477,20 @@ describe("Watcher", () => {
       relistIntervalSec: 0.1,
     });
 
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(
-        () => reject(new Error("Timed out waiting for second relist")),
-        5000,
-      );
+    let listCount = 0;
+    await startAndWaitFor(watcher, WatchEvent.LIST, () => ++listCount >= 2);
 
-      let listCount = 0;
-      watcher.events.on(WatchEvent.LIST, () => {
-        listCount++;
-        if (listCount >= 2) {
-          // Give a brief moment for processing, then resolve
-          setTimeout(() => {
-            clearTimeout(timeout);
-            resolve();
-          }, 100);
-        }
-      });
-
-      watcher.start().catch(reject);
-    });
-
-    // Callback should only be called once (first list adds it, second list sees same RV and skips)
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
   it("should emit LIST_ERROR and skip callback when 429 exhausts retries", async () => {
     const namespace = "list-429-test";
 
-    // List returns 429 with retry-after header
     for (let i = 0; i <= 5; i++) {
       mockClient
-        .intercept({
-          path: `/api/v1/namespaces/${namespace}/pods`,
-          method: "GET",
-        })
+        .intercept({ path: `/api/v1/namespaces/${namespace}/pods`, method: "GET" })
         .reply(429, { message: "Too Many Requests" }, { headers: { "retry-after": "0" } });
     }
-
-    // Watch mock (may not be reached)
     mockClient
       .intercept({
         path: new RegExp(`/api/v1/namespaces/${namespace}/pods\\?watch=true`),
@@ -666,14 +505,11 @@ describe("Watcher", () => {
       resyncDelaySec: 60,
       lastSeenLimitSeconds: 60,
     });
-
     watcher.events.on(WatchEvent.LIST_ERROR, (err: Error) => listErrors.push(err));
 
     await watcher.start();
 
-    // LIST_ERROR should have been emitted
     expect(listErrors.length).toBeGreaterThan(0);
-    // Callback should not have been called (list failed, no items processed)
     expect(callback).not.toHaveBeenCalled();
   });
 
@@ -681,124 +517,43 @@ describe("Watcher", () => {
     const namespace = "await-process-test";
     const processOrder: string[] = [];
 
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods`,
-        method: "GET",
-      })
-      .reply(200, {
-        kind: "PodList",
-        apiVersion: "v1",
-        metadata: { resourceVersion: "50" },
-        items: [createMockPod("pod-a", "1", "uid-a"), createMockPod("pod-b", "1", "uid-b")],
-      });
+    mockListAndWatch(
+      namespace,
+      [createMockPod("pod-a", "1", "uid-a"), createMockPod("pod-b", "1", "uid-b")],
+      "50",
+    );
 
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=50`,
-        method: "GET",
-      })
-      .reply(200);
-
-    const callback = vi
-      .fn<(pod: kind.Pod, phase: WatchPhase) => Promise<void>>()
-      .mockImplementation(async pod => {
-        // Simulate async work
-        await new Promise(r => setTimeout(r, 10));
-        processOrder.push(pod.metadata!.name!);
-      });
+    const callback = vi.fn().mockImplementation(async (pod: kind.Pod) => {
+      await new Promise(r => setTimeout(r, 10));
+      processOrder.push(pod.metadata!.name!);
+    });
 
     watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
       resyncDelaySec: 60,
       lastSeenLimitSeconds: 60,
     });
 
-    const dataErrors: Error[] = [];
-    watcher.events.on(WatchEvent.DATA_ERROR, (err: Error) => dataErrors.push(err));
-
     await watcher.start();
 
-    // Both callbacks completed (awaited, not fire-and-forget)
     expect(callback).toHaveBeenCalledTimes(2);
     expect(processOrder).toEqual(["pod-a", "pod-b"]);
-    // No unhandled errors
-    expect(dataErrors).toEqual([]);
   });
 
   it("should retry delete when delete callback fails", async () => {
     const namespace = "delete-retry-test";
     let deleteCallCount = 0;
 
-    // First list: item exists, callback succeeds (caches it)
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods`,
-        method: "GET",
-      })
-      .reply(200, {
-        kind: "PodList",
-        apiVersion: "v1",
-        metadata: { resourceVersion: "50" },
-        items: [createMockPod("del-pod", "1", "del-pod-uid")],
-      });
+    // List 1: item exists → caches it. Lists 2-3: item gone → triggers delete.
+    mockListAndWatch(namespace, [createMockPod("del-pod", "1", "del-pod-uid")], "50");
+    mockListAndWatch(namespace, [], "51");
+    mockListAndWatch(namespace, [], "52");
 
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=50`,
-        method: "GET",
-      })
-      .reply(200);
-
-    // Second list (relist): item is GONE, triggering delete. Callback fails.
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods`,
-        method: "GET",
-      })
-      .reply(200, {
-        kind: "PodList",
-        apiVersion: "v1",
-        metadata: { resourceVersion: "51" },
-        items: [], // item removed
-      });
-
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=51`,
-        method: "GET",
-      })
-      .reply(200);
-
-    // Third list (relist): item still GONE. Delete callback succeeds this time.
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods`,
-        method: "GET",
-      })
-      .reply(200, {
-        kind: "PodList",
-        apiVersion: "v1",
-        metadata: { resourceVersion: "52" },
-        items: [],
-      });
-
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=52`,
-        method: "GET",
-      })
-      .reply(200);
-
-    const callback = vi
-      .fn<(pod: kind.Pod, phase: WatchPhase) => Promise<void>>()
-      .mockImplementation(async (_pod, phase) => {
-        if (phase === WatchPhase.Deleted) {
-          deleteCallCount++;
-          if (deleteCallCount === 1) {
-            throw new Error("delete callback failed");
-          }
-        }
-      });
+    const callback = vi.fn().mockImplementation(async (_pod: kind.Pod, phase: WatchPhase) => {
+      if (phase === WatchPhase.Deleted) {
+        deleteCallCount++;
+        if (deleteCallCount === 1) throw new Error("delete callback failed");
+      }
+    });
 
     watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
       resyncDelaySec: 5,
@@ -806,188 +561,47 @@ describe("Watcher", () => {
       relistIntervalSec: 0.1,
     });
 
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(
-        () => reject(new Error("Timed out waiting for delete retry")),
-        5000,
-      );
-
-      let listCount = 0;
-      watcher.events.on(WatchEvent.LIST, () => {
-        listCount++;
-        if (listCount >= 3) {
-          setTimeout(() => {
-            clearTimeout(timeout);
-            resolve();
-          }, 200);
-        }
-      });
-
-      watcher.start().catch(reject);
-    });
-
-    // Delete callback was called at least twice (first failed, second succeeded)
+    let listCount = 0;
+    await startAndWaitFor(watcher, WatchEvent.LIST, () => ++listCount >= 3);
     expect(deleteCallCount).toBeGreaterThanOrEqual(2);
   });
 
-  it("should trigger faster resync when callback fails during list", async () => {
-    const namespace = "callback-fail-resync-test";
-
-    // Provide list/watch interceptors for multiple reconnect cycles
-    for (let i = 0; i < 5; i++) {
-      mockClient
-        .intercept({ path: `/api/v1/namespaces/${namespace}/pods`, method: "GET" })
-        .reply(200, {
-          kind: "PodList",
-          apiVersion: "v1",
-          metadata: { resourceVersion: String(50 + i) },
-          items: [createMockPod("fail-pod", "1", "fail-resync-uid")],
-        });
-
-      mockClient
-        .intercept({
-          path: new RegExp(`/api/v1/namespaces/${namespace}/pods\\?watch=true`),
-          method: "GET",
-        })
-        .reply(200);
-    }
-
-    let callCount = 0;
-    const callback = vi
-      .fn<(pod: kind.Pod, phase: WatchPhase) => Promise<void>>()
-      .mockImplementation(async () => {
-        callCount++;
-        if (callCount <= 2) {
-          throw new Error("callback fails");
+  it.each([
+    {
+      name: "callback failure during list",
+      setup: (ns: string) => {
+        for (let i = 0; i < 5; i++)
+          mockListAndWatch(ns, [createMockPod("p", "1", "uid")], String(50 + i));
+      },
+      callback: (() => {
+        let n = 0;
+        return async () => {
+          if (++n <= 2) throw new Error("callback fails");
+        };
+      })(),
+    },
+    {
+      name: "relist timer HTTP 500",
+      setup: (ns: string) => {
+        // First list succeeds, subsequent lists return 500
+        mockListAndWatch(ns, [], "50");
+        for (let i = 0; i < 5; i++) {
+          mockClient
+            .intercept({ path: `/api/v1/namespaces/${ns}/pods`, method: "GET" })
+            .reply(500, { message: "Internal Server Error" });
+          mockClient
+            .intercept({
+              path: new RegExp(`/api/v1/namespaces/${ns}/pods\\?watch=true`),
+              method: "GET",
+            })
+            .reply(200);
         }
-      });
-
-    watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
-      resyncDelaySec: 0.01,
-      lastSeenLimitSeconds: 0.01,
-    });
-
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(
-        () => reject(new Error("Timed out waiting for resync after callback failure")),
-        10000,
-      );
-
-      watcher.events.on(WatchEvent.RECONNECT, () => {
-        clearTimeout(timeout);
-        resolve();
-      });
-
-      watcher.start().catch(reject);
-    });
-
-    // A RECONNECT was triggered because the callback failure caused #list to return false
-    expect(callCount).toBeGreaterThanOrEqual(1);
-  });
-
-  it("should not run concurrent list operations", async () => {
-    const namespace = "concurrent-list-test";
-    let concurrentLists = 0;
-    let maxConcurrentLists = 0;
-
-    // Provide many list/watch interceptors for reconnect cycles
-    for (let i = 0; i < 10; i++) {
-      mockClient
-        .intercept({ path: `/api/v1/namespaces/${namespace}/pods`, method: "GET" })
-        .reply(200, {
-          kind: "PodList",
-          apiVersion: "v1",
-          metadata: { resourceVersion: String(50 + i) },
-          items: [createMockPod("slow-pod", "1", "slow-pod-uid")],
-        });
-
-      mockClient
-        .intercept({
-          path: new RegExp(`/api/v1/namespaces/${namespace}/pods\\?watch=true`),
-          method: "GET",
-        })
-        .reply(200);
-    }
-
-    const callback = vi
-      .fn<(pod: kind.Pod, phase: WatchPhase) => Promise<void>>()
-      .mockImplementation(async () => {
-        concurrentLists++;
-        maxConcurrentLists = Math.max(maxConcurrentLists, concurrentLists);
-        // Slow callback to widen the race window
-        await new Promise(r => setTimeout(r, 100));
-        concurrentLists--;
-      });
-
-    watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
-      resyncDelaySec: 5,
-      lastSeenLimitSeconds: 30,
-      relistIntervalSec: 0.05, // Very short relist interval to trigger overlap attempts
-    });
-
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(
-        () => reject(new Error("Timed out waiting for relist cycles")),
-        5000,
-      );
-
-      let listCount = 0;
-      watcher.events.on(WatchEvent.LIST, () => {
-        listCount++;
-        if (listCount >= 3) {
-          clearTimeout(timeout);
-          resolve();
-        }
-      });
-
-      watcher.start().catch(reject);
-    });
-
-    // At no point should more than one list operation have been processing concurrently
-    expect(maxConcurrentLists).toBeLessThanOrEqual(1);
-  });
-
-  it("should trigger faster resync when relist timer list fails", async () => {
-    const namespace = "relist-fail-resync-test";
-
-    // First list (from #watch) succeeds
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods`,
-        method: "GET",
-      })
-      .reply(200, {
-        kind: "PodList",
-        apiVersion: "v1",
-        metadata: { resourceVersion: "50" },
-        items: [],
-      });
-
-    mockClient
-      .intercept({
-        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=50`,
-        method: "GET",
-      })
-      .reply(200);
-
-    // Relist (from timer) fails with 500
-    for (let i = 0; i < 5; i++) {
-      mockClient
-        .intercept({
-          path: `/api/v1/namespaces/${namespace}/pods`,
-          method: "GET",
-        })
-        .reply(500, { message: "Internal Server Error" });
-
-      mockClient
-        .intercept({
-          path: new RegExp(`/api/v1/namespaces/${namespace}/pods\\?watch=true`),
-          method: "GET",
-        })
-        .reply(200);
-    }
-
-    const callback = vi.fn();
+      },
+      callback: vi.fn(),
+    },
+  ])("should trigger faster resync on $name", async ({ setup, callback }) => {
+    const namespace = `resync-${Date.now()}`;
+    setup(namespace);
 
     watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
       resyncDelaySec: 0.01,
@@ -995,31 +609,42 @@ describe("Watcher", () => {
       relistIntervalSec: 0.05,
     });
 
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(
-        () => reject(new Error("Timed out waiting for reconnect after relist failure")),
-        5000,
-      );
+    await startAndWaitFor(watcher, WatchEvent.RECONNECT);
+  });
 
-      watcher.events.on(WatchEvent.RECONNECT, () => {
-        clearTimeout(timeout);
-        resolve();
-      });
+  it("should not run concurrent list operations", async () => {
+    const namespace = "concurrent-list-test";
+    let concurrentLists = 0;
+    let maxConcurrentLists = 0;
 
-      watcher.start().catch(reject);
+    for (let i = 0; i < 10; i++) {
+      mockListAndWatch(namespace, [createMockPod("slow-pod", "1", "slow-pod-uid")], String(50 + i));
+    }
+
+    const callback = vi.fn().mockImplementation(async () => {
+      concurrentLists++;
+      maxConcurrentLists = Math.max(maxConcurrentLists, concurrentLists);
+      await new Promise(r => setTimeout(r, 100));
+      concurrentLists--;
     });
+
+    watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
+      resyncDelaySec: 5,
+      lastSeenLimitSeconds: 30,
+      relistIntervalSec: 0.05,
+    });
+
+    let listCount = 0;
+    await startAndWaitFor(watcher, WatchEvent.LIST, () => ++listCount >= 3);
+    expect(maxConcurrentLists).toBeLessThanOrEqual(1);
   });
 
   it("should stop pagination at maximum page limit", async () => {
     const namespace = "max-pages-test";
 
-    // Mock 12 pages of results, each with a continue token (except the last)
     for (let i = 0; i < 12; i++) {
       mockClient
-        .intercept({
-          path: new RegExp(`/api/v1/namespaces/${namespace}/pods`),
-          method: "GET",
-        })
+        .intercept({ path: new RegExp(`/api/v1/namespaces/${namespace}/pods`), method: "GET" })
         .reply(200, {
           kind: "PodList",
           apiVersion: "v1",
@@ -1030,7 +655,6 @@ describe("Watcher", () => {
           items: [createMockPod(`pod-page-${i}`, "1", `uid-page-${i}`)],
         });
     }
-
     mockClient
       .intercept({
         path: new RegExp(`/api/v1/namespaces/${namespace}/pods\\?watch=true`),
@@ -1045,16 +669,12 @@ describe("Watcher", () => {
       resyncDelaySec: 60,
       lastSeenLimitSeconds: 60,
     });
-
     watcher.events.on(WatchEvent.LIST_ERROR, (err: Error) =>
       listErrors.push(err?.message ?? String(err)),
     );
 
     await watcher.start();
-
-    // Should have hit the pagination limit
-    const paginationError = listErrors.find(msg => msg.includes("Maximum pagination limit"));
-    expect(paginationError).toBeDefined();
+    expect(listErrors.find(msg => msg.includes("Maximum pagination limit"))).toBeDefined();
   });
 
   it("should trigger reconnect after non-OK watch response", async () => {
@@ -1116,6 +736,53 @@ describe("Watcher", () => {
     });
   });
 });
+
+/**
+ * Mock a list response followed by a watch endpoint for a namespace.
+ *
+ * @param ns
+ * @param items
+ * @param rv
+ * @param watchError
+ */
+function mockListAndWatch(ns: string, items: kind.Pod[], rv: string, watchError?: Error) {
+  mockClient
+    .intercept({ path: `/api/v1/namespaces/${ns}/pods`, method: "GET" })
+    .reply(200, { kind: "PodList", apiVersion: "v1", metadata: { resourceVersion: rv }, items });
+
+  const watchIntercept = mockClient.intercept({
+    path: new RegExp(`/api/v1/namespaces/${ns}/pods\\?watch=true`),
+    method: "GET",
+  });
+  if (watchError) watchIntercept.replyWithError(watchError);
+  else watchIntercept.reply(200);
+}
+
+/**
+ * Start a watcher and resolve when `event` fires (optionally gated by `predicate`).
+ *
+ * @param w
+ * @param event
+ * @param predicate
+ * @param timeoutMs
+ */
+function startAndWaitFor(
+  w: Watcher<typeof kind.Pod>,
+  event: WatchEvent,
+  predicate?: () => boolean,
+  timeoutMs = 10000,
+) {
+  return new Promise<void>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`Timed out waiting for ${event}`)), timeoutMs);
+    w.events.on(event, () => {
+      if (!predicate || predicate()) {
+        clearTimeout(t);
+        resolve();
+      }
+    });
+    w.start().catch(reject);
+  });
+}
 
 /**
  * Creates a mock pod object

--- a/src/fluent/watch.test.ts
+++ b/src/fluent/watch.test.ts
@@ -643,6 +643,71 @@ describe("Watcher", () => {
     expect(maxConcurrentLists).toBeLessThanOrEqual(1);
   });
 
+  it("should propagate callback failure across pagination boundaries", async () => {
+    const namespace = "page-fail-propagate-test";
+
+    // Page 1: has an item whose callback will fail
+    mockClient
+      .intercept({ path: `/api/v1/namespaces/${namespace}/pods`, method: "GET" })
+      .reply(200, {
+        kind: "PodList",
+        apiVersion: "v1",
+        metadata: { resourceVersion: "50", continue: "page2-token" },
+        items: [createMockPod("fail-pod", "1", "fail-uid")],
+      });
+
+    // Page 2: succeeds with a different item
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods?continue=page2-token`,
+        method: "GET",
+      })
+      .reply(200, {
+        kind: "PodList",
+        apiVersion: "v1",
+        metadata: { resourceVersion: "51" },
+        items: [createMockPod("ok-pod", "1", "ok-uid")],
+      });
+
+    // Provide watch + relist mocks for the reconnect cycle
+    for (let i = 0; i < 5; i++) {
+      mockClient
+        .intercept({
+          path: new RegExp(`/api/v1/namespaces/${namespace}/pods\\?watch=true`),
+          method: "GET",
+        })
+        .reply(200);
+      mockClient
+        .intercept({ path: `/api/v1/namespaces/${namespace}/pods`, method: "GET" })
+        .reply(200, {
+          kind: "PodList",
+          apiVersion: "v1",
+          metadata: { resourceVersion: String(52 + i) },
+          items: [
+            createMockPod("fail-pod", "1", "fail-uid"),
+            createMockPod("ok-pod", "1", "ok-uid"),
+          ],
+        });
+    }
+
+    let callCount = 0;
+    const callback = vi.fn().mockImplementation(async (pod: kind.Pod) => {
+      callCount++;
+      // Fail only on the first item (page 1)
+      if (pod.metadata!.uid === "fail-uid" && callCount === 1) {
+        throw new Error("page 1 callback fails");
+      }
+    });
+
+    watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
+      resyncDelaySec: 0.01,
+      lastSeenLimitSeconds: 0.01,
+    });
+
+    // The page-1 failure should propagate, triggering a RECONNECT for faster resync
+    await startAndWaitFor(watcher, WatchEvent.RECONNECT);
+  });
+
   it("should stop pagination at maximum page limit", async () => {
     const namespace = "max-pages-test";
 

--- a/src/fluent/watch.test.ts
+++ b/src/fluent/watch.test.ts
@@ -1010,6 +1010,53 @@ describe("Watcher", () => {
     });
   });
 
+  it("should stop pagination at maximum page limit", async () => {
+    const namespace = "max-pages-test";
+
+    // Mock 12 pages of results, each with a continue token (except the last)
+    for (let i = 0; i < 12; i++) {
+      mockClient
+        .intercept({
+          path: new RegExp(`/api/v1/namespaces/${namespace}/pods`),
+          method: "GET",
+        })
+        .reply(200, {
+          kind: "PodList",
+          apiVersion: "v1",
+          metadata: {
+            resourceVersion: String(50 + i),
+            ...(i < 11 ? { continue: `page-${i + 1}-token` } : {}),
+          },
+          items: [createMockPod(`pod-page-${i}`, "1", `uid-page-${i}`)],
+        });
+    }
+
+    mockClient
+      .intercept({
+        path: new RegExp(`/api/v1/namespaces/${namespace}/pods\\?watch=true`),
+        method: "GET",
+      })
+      .reply(200);
+
+    const listErrors: string[] = [];
+    const callback = vi.fn();
+
+    watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
+      resyncDelaySec: 60,
+      lastSeenLimitSeconds: 60,
+    });
+
+    watcher.events.on(WatchEvent.LIST_ERROR, (err: Error) =>
+      listErrors.push(err?.message ?? String(err)),
+    );
+
+    await watcher.start();
+
+    // Should have hit the pagination limit
+    const paginationError = listErrors.find(msg => msg.includes("Maximum pagination limit"));
+    expect(paginationError).toBeDefined();
+  });
+
   it("should trigger reconnect after non-OK watch response", async () => {
     const namespace = "reconnect-test";
 

--- a/src/fluent/watch.test.ts
+++ b/src/fluent/watch.test.ts
@@ -458,6 +458,50 @@ describe("Watcher", () => {
     expect(dataErrors[0].message).toBe("callback failed");
   });
 
+  it("should not emit DATA when callback throws", async () => {
+    const namespace = "data-no-emit-test";
+
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods`,
+        method: "GET",
+      })
+      .reply(200, {
+        kind: "PodList",
+        apiVersion: "v1",
+        metadata: { resourceVersion: "50" },
+        items: [createMockPod("fail-pod", "1", "data-fail-uid")],
+      });
+
+    mockClient
+      .intercept({
+        path: `/api/v1/namespaces/${namespace}/pods?watch=true&resourceVersion=50`,
+        method: "GET",
+      })
+      .reply(200);
+
+    const callback = vi
+      .fn<(pod: kind.Pod, phase: WatchPhase) => Promise<void>>()
+      .mockRejectedValue(new Error("callback throws"));
+
+    watcher = K8s(kind.Pod).InNamespace(namespace).Watch(callback, {
+      resyncDelaySec: 5,
+      lastSeenLimitSeconds: 30,
+    });
+
+    const dataEvents: kind.Pod[] = [];
+    const dataErrors: Error[] = [];
+    watcher.events.on(WatchEvent.DATA, (pod: kind.Pod) => dataEvents.push(pod));
+    watcher.events.on(WatchEvent.DATA_ERROR, (err: Error) => dataErrors.push(err));
+
+    await watcher.start();
+
+    // DATA should NOT have been emitted since callback threw
+    expect(dataEvents.length).toBe(0);
+    // DATA_ERROR should have been emitted
+    expect(dataErrors.length).toBe(1);
+  });
+
   it("should retry failed items on next relist via reconnect", async () => {
     const namespace = "relist-retry-test";
     let callCount = 0;

--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -246,7 +246,7 @@ export class Watcher<T extends GenericClass> {
    * @param continueToken - the continue token for the list
    * @param removedItems - the list of items that have been removed
    * @param retryCount - current retry attempt count
-   * @param pageCount
+   * @param pageCount - number of continuation pages already fetched (0-based)
    * @returns resolves when list processing is complete
    */
   #list = async (

--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -388,9 +388,6 @@ export class Watcher<T extends GenericClass> {
    * @param phase - the event phase
    */
   #process = async (payload: InstanceType<T>, phase: WatchPhase) => {
-    // Emit the data event before callback (informational)
-    this.#events.emit(WatchEvent.DATA, payload, phase);
-
     // Call the callback function — if it throws, the cache is NOT updated
     // so the next relist will detect the item as unprocessed and retry
     await this.#callback(payload, phase);
@@ -406,6 +403,9 @@ export class Watcher<T extends GenericClass> {
         this.#cache.delete(payload.metadata.uid);
         break;
     }
+
+    // Emit data event only after callback succeeds and cache is updated
+    this.#events.emit(WatchEvent.DATA, payload, phase);
   };
 
   // process a line from the chunk

--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -364,7 +364,7 @@ export class Watcher<T extends GenericClass> {
         }
 
         // Continue pagination (not a retry, so reset retryCount to 0)
-        return this.#list(continueToken, removedItems, 0, pageCount + 1);
+        return await this.#list(continueToken, removedItems, 0, pageCount + 1);
       } else {
         // Otherwise, process the removed items
         for (const item of removedItems.values()) {

--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -312,6 +312,8 @@ export class Watcher<T extends GenericClass> {
       // If removed items are not provided, clone the cache
       removedItems = removedItems || new Map(this.#cache.entries());
 
+      let anyCallbackFailed = false;
+
       // Process each item in the list
       for (const item of list.items || []) {
         const { uid } = item.metadata;
@@ -325,6 +327,7 @@ export class Watcher<T extends GenericClass> {
           try {
             await this.#process(item, WatchPhase.Added);
           } catch (err) {
+            anyCallbackFailed = true;
             this.#events.emit(WatchEvent.DATA_ERROR, err);
           }
           continue;
@@ -340,6 +343,7 @@ export class Watcher<T extends GenericClass> {
           try {
             await this.#process(item, WatchPhase.Modified);
           } catch (err) {
+            anyCallbackFailed = true;
             this.#events.emit(WatchEvent.DATA_ERROR, err);
           }
         }
@@ -365,12 +369,13 @@ export class Watcher<T extends GenericClass> {
           try {
             await this.#process(item, WatchPhase.Deleted);
           } catch (err) {
+            anyCallbackFailed = true;
             this.#events.emit(WatchEvent.DATA_ERROR, err);
           }
         }
       }
 
-      return true;
+      return !anyCallbackFailed;
     } catch (err) {
       this.#events.emit(WatchEvent.LIST_ERROR, err);
       return false;

--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -325,6 +325,8 @@ export class Watcher<T extends GenericClass> {
         if (!alreadyExists) {
           this.#events.emit(WatchEvent.CACHE_MISS, this.#latestRelistWindow);
           try {
+            // Keep lastSeenTime fresh to prevent spurious resync during slow list processing
+            this.#lastSeenTime = Date.now();
             await this.#process(item, WatchPhase.Added);
           } catch (err) {
             anyCallbackFailed = true;
@@ -341,6 +343,7 @@ export class Watcher<T extends GenericClass> {
         if (itemRV > cachedRV) {
           this.#events.emit(WatchEvent.CACHE_MISS, this.#latestRelistWindow);
           try {
+            this.#lastSeenTime = Date.now();
             await this.#process(item, WatchPhase.Modified);
           } catch (err) {
             anyCallbackFailed = true;
@@ -367,6 +370,7 @@ export class Watcher<T extends GenericClass> {
         for (const item of removedItems.values()) {
           this.#events.emit(WatchEvent.CACHE_MISS, this.#latestRelistWindow);
           try {
+            this.#lastSeenTime = Date.now();
             await this.#process(item, WatchPhase.Deleted);
           } catch (err) {
             anyCallbackFailed = true;

--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -246,12 +246,14 @@ export class Watcher<T extends GenericClass> {
    * @param continueToken - the continue token for the list
    * @param removedItems - the list of items that have been removed
    * @param retryCount - current retry attempt count
+   * @param pageCount
    * @returns resolves when list processing is complete
    */
   #list = async (
     continueToken?: string,
     removedItems?: Map<string, InstanceType<T>>,
     retryCount = 0,
+    pageCount = 0,
   ): Promise<boolean> => {
     const isTopLevel = !continueToken && !removedItems;
     if (isTopLevel) {
@@ -288,7 +290,7 @@ export class Watcher<T extends GenericClass> {
 
           await sleep(backoffTime);
           try {
-            return this.#list(continueToken, removedItems, retryCount + 1);
+            return this.#list(continueToken, removedItems, retryCount + 1, pageCount);
           } catch (e) {
             this.#events.emit(
               WatchEvent.LIST_ERROR,
@@ -355,7 +357,7 @@ export class Watcher<T extends GenericClass> {
       // If there is a continue token, call the list function again with the same removed items
       if (continueToken) {
         // Safeguard against infinite pagination
-        if (retryCount >= maxPages) {
+        if (pageCount >= maxPages) {
           this.#events.emit(
             WatchEvent.LIST_ERROR,
             new Error(`Maximum pagination limit (${maxPages}) reached, stopping list operation`),
@@ -364,7 +366,7 @@ export class Watcher<T extends GenericClass> {
         }
 
         // Continue pagination (not a retry, so reset retryCount to 0)
-        return this.#list(continueToken, removedItems, 0);
+        return this.#list(continueToken, removedItems, 0, pageCount + 1);
       } else {
         // Otherwise, process the removed items
         for (const item of removedItems.values()) {

--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -96,6 +96,9 @@ export class Watcher<T extends GenericClass> {
   // Track if a reconnect is pending
   #pendingReconnect = false;
 
+  // Track if a list operation is in progress to prevent concurrent lists
+  #listInProgress = false;
+
   // The resource version to start the watch at, this will be updated after the list operation.
   #resourceVersion?: string;
 
@@ -138,7 +141,12 @@ export class Watcher<T extends GenericClass> {
       () => {
         this.#latestRelistWindow = new Date().toISOString();
         this.#events.emit(WatchEvent.INIT_CACHE_MISS, this.#latestRelistWindow);
-        void this.#list();
+        void (async () => {
+          const success = await this.#list();
+          if (!success) {
+            this.#lastSeenTime = OVERRIDE;
+          }
+        })();
       },
       watchCfg.relistIntervalSec * 1000 + jitter,
     );
@@ -245,6 +253,14 @@ export class Watcher<T extends GenericClass> {
     removedItems?: Map<string, InstanceType<T>>,
     retryCount = 0,
   ): Promise<boolean> => {
+    const isTopLevel = !continueToken && !removedItems;
+    if (isTopLevel) {
+      if (this.#listInProgress) {
+        return false;
+      }
+      this.#listInProgress = true;
+    }
+
     const maxRetries = 5;
     const maxPages = 10;
 
@@ -358,6 +374,10 @@ export class Watcher<T extends GenericClass> {
     } catch (err) {
       this.#events.emit(WatchEvent.LIST_ERROR, err);
       return false;
+    } finally {
+      if (isTopLevel) {
+        this.#listInProgress = false;
+      }
     }
   };
 

--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -288,7 +288,7 @@ export class Watcher<T extends GenericClass> {
 
           await sleep(backoffTime);
           try {
-            return this.#list(continueToken, removedItems, retryCount + 1, pageCount);
+            return await this.#list(continueToken, removedItems, retryCount + 1, pageCount);
           } catch (e) {
             this.#events.emit(
               WatchEvent.LIST_ERROR,

--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -255,7 +255,7 @@ export class Watcher<T extends GenericClass> {
     retryCount = 0,
     pageCount = 0,
   ): Promise<boolean> => {
-    const isTopLevel = !continueToken && !removedItems;
+    const isTopLevel = !continueToken && !removedItems && retryCount === 0;
     if (isTopLevel) {
       if (this.#listInProgress) {
         return false;

--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -12,7 +12,7 @@ import {
   WatchAction,
   WatchPhase,
 } from "./shared-types.js";
-import { getHeaders, k8sCfg, pathBuilder, sleep, startSleep } from "./utils.js";
+import { getHeaders, k8sCfg, pathBuilder, sleep } from "./utils.js";
 
 export enum WatchEvent {
   /** Watch is connected successfully */
@@ -284,9 +284,7 @@ export class Watcher<T extends GenericClass> {
         const retryAfterHeader = response.headers.get("retry-after");
         // Retry with exponential backoff if under retry limit to prevent infinite recursion if the server is returning errors
         if (retryCount < maxRetries && retryAfterHeader) {
-          const backoffTime = retryAfterHeader
-            ? parseInt(retryAfterHeader) * 1000
-            : Math.min(startSleep * Math.pow(2, retryCount), 30000);
+          const backoffTime = parseInt(retryAfterHeader) * 1000;
 
           await sleep(backoffTime);
           try {

--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -440,7 +440,9 @@ export class Watcher<T extends GenericClass> {
         };
       }
 
-      // Process the event payload, do not update the resource version as that is handled by the list operation
+      // Process the event payload, do not update the resource version as that is handled by the list operation.
+      // Watch-stream events are not retried on callback failure — the relist timer
+      // will re-detect unprocessed items on its next cycle.
       await process(payload, phase);
     } catch (err) {
       if (err.name === "TooOld") {

--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -244,7 +244,7 @@ export class Watcher<T extends GenericClass> {
     continueToken?: string,
     removedItems?: Map<string, InstanceType<T>>,
     retryCount = 0,
-  ): Promise<void> => {
+  ): Promise<boolean> => {
     const maxRetries = 5;
     const maxPages = 10;
 
@@ -281,7 +281,7 @@ export class Watcher<T extends GenericClass> {
           }
         }
 
-        return;
+        return false;
       }
 
       // Unconditionally assign the continue token from the response so that it is cleared on the last page
@@ -306,8 +306,11 @@ export class Watcher<T extends GenericClass> {
         // If the item does not exist, it is new and should be added
         if (!alreadyExists) {
           this.#events.emit(WatchEvent.CACHE_MISS, this.#latestRelistWindow);
-          // Send added event. Use void here because we don't care about the result (no consequences here if it fails)
-          void this.#process(item, WatchPhase.Added);
+          try {
+            await this.#process(item, WatchPhase.Added);
+          } catch (err) {
+            this.#events.emit(WatchEvent.DATA_ERROR, err);
+          }
           continue;
         }
 
@@ -318,8 +321,11 @@ export class Watcher<T extends GenericClass> {
         // Check if the resource version is newer than the cached version
         if (itemRV > cachedRV) {
           this.#events.emit(WatchEvent.CACHE_MISS, this.#latestRelistWindow);
-          // Send a modified event if the resource version has changed
-          void this.#process(item, WatchPhase.Modified);
+          try {
+            await this.#process(item, WatchPhase.Modified);
+          } catch (err) {
+            this.#events.emit(WatchEvent.DATA_ERROR, err);
+          }
         }
       }
 
@@ -331,20 +337,27 @@ export class Watcher<T extends GenericClass> {
             WatchEvent.LIST_ERROR,
             new Error(`Maximum pagination limit (${maxPages}) reached, stopping list operation`),
           );
-          return;
+          return false;
         }
 
         // Continue pagination (not a retry, so reset retryCount to 0)
-        await this.#list(continueToken, removedItems, 0);
+        return this.#list(continueToken, removedItems, 0);
       } else {
         // Otherwise, process the removed items
         for (const item of removedItems.values()) {
           this.#events.emit(WatchEvent.CACHE_MISS, this.#latestRelistWindow);
-          void this.#process(item, WatchPhase.Deleted);
+          try {
+            await this.#process(item, WatchPhase.Deleted);
+          } catch (err) {
+            this.#events.emit(WatchEvent.DATA_ERROR, err);
+          }
         }
       }
+
+      return true;
     } catch (err) {
       this.#events.emit(WatchEvent.LIST_ERROR, err);
+      return false;
     }
   };
 
@@ -355,27 +368,23 @@ export class Watcher<T extends GenericClass> {
    * @param phase - the event phase
    */
   #process = async (payload: InstanceType<T>, phase: WatchPhase) => {
-    try {
-      switch (phase) {
-        // If the event is added or modified, update the cache
-        case WatchPhase.Added:
-        case WatchPhase.Modified:
-          this.#cache.set(payload.metadata.uid, payload);
-          break;
+    // Emit the data event before callback (informational)
+    this.#events.emit(WatchEvent.DATA, payload, phase);
 
-        // If the event is deleted, remove the item from the cache
-        case WatchPhase.Deleted:
-          this.#cache.delete(payload.metadata.uid);
-          break;
-      }
+    // Call the callback function — if it throws, the cache is NOT updated
+    // so the next relist will detect the item as unprocessed and retry
+    await this.#callback(payload, phase);
 
-      // Emit the data event
-      this.#events.emit(WatchEvent.DATA, payload, phase);
+    // Only update cache after the callback succeeds
+    switch (phase) {
+      case WatchPhase.Added:
+      case WatchPhase.Modified:
+        this.#cache.set(payload.metadata.uid, payload);
+        break;
 
-      // Call the callback function with the parsed payload
-      await this.#callback(payload, phase);
-    } catch (err) {
-      this.#events.emit(WatchEvent.DATA_ERROR, err);
+      case WatchPhase.Deleted:
+        this.#cache.delete(payload.metadata.uid);
+        break;
     }
   };
 
@@ -422,11 +431,17 @@ export class Watcher<T extends GenericClass> {
    */
   #watch = async (retryCount = 0): Promise<void> => {
     const maxRetries = 5;
-    // Start with a list operation, but don't let it block the watch stream
+    // Start with a list operation
+    let listSucceeded = false;
     try {
-      await this.#list();
+      listSucceeded = await this.#list();
     } catch (listError) {
       this.#events.emit(WatchEvent.LIST_ERROR, listError);
+    }
+
+    // If the list failed, trigger a faster resync so items aren't permanently missed
+    if (!listSucceeded) {
+      this.#lastSeenTime = OVERRIDE;
     }
 
     // Build the URL and request options

--- a/src/fluent/watch.ts
+++ b/src/fluent/watch.ts
@@ -363,8 +363,11 @@ export class Watcher<T extends GenericClass> {
           return false;
         }
 
-        // Continue pagination (not a retry, so reset retryCount to 0)
-        return await this.#list(continueToken, removedItems, 0, pageCount + 1);
+        // Continue pagination (not a retry, so reset retryCount to 0).
+        // Combine with current page's failure state so a callback failure on
+        // an earlier page is not masked by a successful later page.
+        const nextPageSucceeded = await this.#list(continueToken, removedItems, 0, pageCount + 1);
+        return !anyCallbackFailed && nextPageSucceeded;
       } else {
         // Otherwise, process the removed items
         for (const item of removedItems.values()) {


### PR DESCRIPTION
## Summary

- **Reorder `#process`** to update the cache only after the callback succeeds. Previously, items were cached before the callback ran — a failed callback left the item permanently stuck in cache, invisible to the application.
- **Guard concurrent `#list()` calls** with a `#listInProgress` flag to prevent cache corruption when the relist timer fires during an in-progress list.
- **Await `#process` calls in `#list()`** instead of fire-and-forget (`void`), ensuring list reconciliation completes atomically.
- **Return success/failure from `#list()`** so both `#watch()` and the relist timer can trigger faster resync when list operations or callbacks fail.
- **Emit `DATA` event only after callback succeeds and cache is updated**, eliminating phantom events for items that failed processing.
- **Refresh `lastSeenTime` during list processing** to prevent spurious resync triggers during slow callback sequences.
- **Fix dead pagination guard** by separating `pageCount` from `retryCount` — the guard could never trigger because `retryCount` was always reset to 0 on pagination.
- **Remove dead backoff ternary** and unused `startSleep` import.

## Context

Production bug in Pepr/UDS Core: K8s API server returns 429 Too Many Requests during EKS cluster bootstrap. The KFC watcher misses `UDSExemption` CRs because:

1. `#process` caches items *before* running callbacks (line 363: `this.#cache.set(...)`)
2. If the callback throws, the error is caught internally (line 377-378) but the item is already in cache
3. On the next `#list()` relist, the item's UID is found in cache at the same resourceVersion → skipped
4. The resource stays invisible until pod restart or manual annotation

Companion Pepr PR: defenseunicorns/pepr#3052

## Changes

### `src/fluent/watch.ts`
- `#process`: Move `cache.set()`/`cache.delete()` after `await this.#callback()`. Move `DATA` emit to after cache update. Remove internal try/catch — callers handle errors.
- `#list()`: Replace `void this.#process()` with `await this.#process()` wrapped in try/catch. Return `boolean` (false on HTTP error, callback failure, or max pages). Add `#listInProgress` concurrency guard with `finally` cleanup. Add `pageCount` parameter for pagination depth tracking. Refresh `lastSeenTime` before each process call. Remove dead backoff ternary.
- `#watch()`: Check `#list()` return value. On failure, set `lastSeenTime = OVERRIDE` to trigger faster resync.
- Relist timer: Await `#list()` return value and trigger faster resync on failure. Skipped if `#listInProgress`.

10 new test cases covering: callback failure (no cache, no DATA, DATA_ERROR emitted), relist retry, cached item skip, 429 exhaustion, sequential processing, delete retry, resync on callback/HTTP failure (table-driven via `it.each`), concurrent list prevention, pagination limit.

## Breaking change analysis

**No breaking changes.** `#process`, `#list()`, `#cache`, and `#listInProgress` are all private. `DATA_ERROR` event signature unchanged. Cache has no public accessor.

**Behavioral change**: `WatchEvent.DATA` now fires only after successful callback + cache update (previously fired before callback). No internal consumers rely on the old timing. External consumers now get a stronger guarantee: DATA means the item was fully processed.

## Test plan

- [x] 10 new test cases covering all fix commits
- [x] All 205 tests pass
- [x] ESLint: 0 errors (pre-existing warnings only)
- [x] TypeScript: no new type errors
- [x] E2E tests against k3d cluster
- [ ] Soak test with Pepr companion PR (defenseunicorns/pepr#3052)

🤖 Generated with [Claude Code](https://claude.com/claude-code)