### PR TITLE
chore: unhide chore commits in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,7 +14,7 @@
         { "type": "test", "section": "Tests", "hidden": true },
         { "type": "build", "section": "Build System", "hidden": true },
         { "type": "ci", "section": "Continuous Integration", "hidden": true },
-        { "type": "chore", "section": "Chores", "hidden": true },
+        { "type": "chore", "section": "Chores" },
         { "type": "deps", "section": "Dependencies" },
         { "type": "*", "section": "Miscellaneous" }
       ]


### PR DESCRIPTION
## Summary
- Removes `"hidden": true` from the `chore` changelog section in release-please config
- Allows chore-type commits (including dependency bumps) to trigger release-please PRs, enabling easier maintenance releases

## Test plan
- [ ] Verify release-please creates a release PR after merge