### PR TITLE
chore: incremental linting for PRs in CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm run format:check:changed
 
       - name: Format check (full)
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_call'
         run: npm run format:check
 
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -32,9 +32,11 @@ jobs:
       - name: Get changed files
         id: changed
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          changed_ts=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- 'src/**' 'e2e/**' | grep -E '\.(ts|js|mts|mjs)$' || true)
-          changed_fmt=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD | grep -E '\.(ts|js|mts|mjs|json|yaml|yml|md)$' || true)
+          changed_ts=$(git diff --name-only --diff-filter=ACMR "origin/$BASE_REF"...HEAD -- 'src/**' 'e2e/**' | grep -E '\.(ts|js|mts|mjs)$' || true)
+          changed_fmt=$(git diff --name-only --diff-filter=ACMR "origin/$BASE_REF"...HEAD | grep -E '\.(ts|js|mts|mjs|json|yaml|yml|md)$' || true)
           echo "ts<<EOF" >> "$GITHUB_OUTPUT"
           echo "$changed_ts" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
@@ -44,11 +46,15 @@ jobs:
 
       - name: Lint (incremental)
         if: steps.changed.outputs.ts != ''
-        run: npx eslint ${{ steps.changed.outputs.ts }}
+        env:
+          CHANGED_TS: ${{ steps.changed.outputs.ts }}
+        run: npx eslint $CHANGED_TS
 
       - name: Prettier (incremental)
         if: steps.changed.outputs.fmt != ''
-        run: npx prettier --check ${{ steps.changed.outputs.fmt }}
+        env:
+          CHANGED_FMT: ${{ steps.changed.outputs.fmt }}
+        run: npx prettier --check $CHANGED_FMT
 
       - name: Lint (full)
         if: github.event_name == 'push'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,34 +29,11 @@ jobs:
 
       - run: npm ci
 
-      - name: Get changed files
-        id: changed
+      - name: Format check (changed files only)
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          changed_ts=$(git diff --name-only --diff-filter=ACMR "origin/$BASE_REF"...HEAD -- 'src/**' 'e2e/**' | grep -E '\.(ts|js|mts|mjs)$' || true)
-          changed_fmt=$(git diff --name-only --diff-filter=ACMR "origin/$BASE_REF"...HEAD | grep -E '\.(ts|js|mts|mjs|json|yaml|yml|md)$' || true)
-          echo "ts<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$changed_ts" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-          echo "fmt<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$changed_fmt" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+        run: npm run format:check:changed
 
-      - name: Lint (incremental)
-        if: steps.changed.outputs.ts != ''
-        env:
-          CHANGED_TS: ${{ steps.changed.outputs.ts }}
-        run: npx eslint $CHANGED_TS
-
-      - name: Prettier (incremental)
-        if: steps.changed.outputs.fmt != ''
-        env:
-          CHANGED_FMT: ${{ steps.changed.outputs.fmt }}
-        run: npx prettier --check $CHANGED_FMT
-
-      - name: Lint (full)
+      - name: Format check (full)
         if: github.event_name == 'push'
         run: npm run format:check
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -26,7 +28,32 @@ jobs:
           cache: npm
 
       - run: npm ci
-      - run: npm run format:check
+
+      - name: Get changed files
+        id: changed
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        run: |
+          changed_ts=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- 'src/**' 'e2e/**' | grep -E '\.(ts|js|mts|mjs)$' || true)
+          changed_fmt=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD | grep -E '\.(ts|js|mts|mjs|json|yaml|yml|md)$' || true)
+          echo "ts<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$changed_ts" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "fmt<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$changed_fmt" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Lint (incremental)
+        if: steps.changed.outputs.ts != ''
+        run: npx eslint ${{ steps.changed.outputs.ts }}
+
+      - name: Prettier (incremental)
+        if: steps.changed.outputs.fmt != ''
+        run: npx prettier --check ${{ steps.changed.outputs.fmt }}
+
+      - name: Lint (full)
+        if: github.event_name == 'push'
+        run: npm run format:check
+
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
         run: npm audit signatures
   test:

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test:e2e:run": "npm run test:e2e:prep-cluster && npm run test:e2e:prep-crds && npm run test:e2e:prep-image && npm run test:e2e && npm run test:e2e:cleanup",
     "test:e2e:cleanup": "k3d cluster delete kfc-dev",
     "format:check": "eslint src e2e && prettier . --check",
+    "format:check:changed": "bash scripts/format-changed.sh",
     "format:fix": "eslint --fix src e2e && prettier . --write",
     "prepare": "if [ \"$NODE_ENV\" != 'production' ]; then husky; fi"
   },

--- a/scripts/format-changed.sh
+++ b/scripts/format-changed.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE="${1:-origin/main}"
+
+ts_files=$(git diff --name-only --diff-filter=ACMRTUXB "$BASE" -- 'src/**' 'e2e/**' | grep -E '\.(ts|js|mts|mjs)$' || true)
+fmt_files=$(git diff --name-only --diff-filter=ACMRTUXB "$BASE" | grep -E '\.(ts|js|mts|mjs|json|yaml|yml|md)$' || true)
+
+if [ -n "$ts_files" ]; then
+  echo "Linting changed files..."
+  npx eslint $ts_files
+else
+  echo "No lint targets changed."
+fi
+
+if [ -n "$fmt_files" ]; then
+  echo "Checking formatting of changed files..."
+  npx prettier --check $fmt_files
+else
+  echo "No format targets changed."
+fi

--- a/scripts/format-changed.sh
+++ b/scripts/format-changed.sh
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE="${1:-origin/main}"
+BASE="${1:-origin/${GITHUB_BASE_REF:-main}}"
 
-ts_files=$(git diff --name-only --diff-filter=ACMRTUXB "$BASE" -- 'src/**' 'e2e/**' | grep -E '\.(ts|js|mts|mjs)$' || true)
-fmt_files=$(git diff --name-only --diff-filter=ACMRTUXB "$BASE" | grep -E '\.(ts|js|mts|mjs|json|yaml|yml|md)$' || true)
+mapfile -t ts_files < <(git diff --name-only --diff-filter=ACMRTUXB "$BASE" -- 'src/**' 'e2e/**' | grep -E '\.(ts|js|mts|mjs)$' || true)
+mapfile -t fmt_files < <(git diff --name-only --diff-filter=ACMRTUXB "$BASE" | grep -E '\.(ts|js|mts|mjs|json|yaml|yml|md)$' || true)
 
-if [ -n "$ts_files" ]; then
+if [ ${#ts_files[@]} -gt 0 ]; then
   echo "Linting changed files..."
-  npx eslint $ts_files
+  npx eslint "${ts_files[@]}"
 else
   echo "No lint targets changed."
 fi
 
-if [ -n "$fmt_files" ]; then
+if [ ${#fmt_files[@]} -gt 0 ]; then
   echo "Checking formatting of changed files..."
-  npx prettier --check $fmt_files
+  npx prettier --check "${fmt_files[@]}"
 else
   echo "No format targets changed."
 fi


### PR DESCRIPTION
## Summary
- PR lint checks now only run on changed files instead of the entire codebase
- Pushes to `main` still run the full lint/format check
- Prevents pre-existing lint warnings (e.g. complexity in `crd-manifests.ts`) from blocking unrelated PRs like release-please

Inspired by `golangci-lint`'s [settings](https://golangci-lint.run/docs/configuration/cli/), but not quite as robust since it's not natively supported by prettier and eslint as far as I could tell:

> `--new-from-merge-base string        Show only new issues created after the best common ancestor (merge-base against HEAD)`


## How it works
- On PRs/merge queue: `git diff` against the base branch to find changed `.ts`/`.js` files for eslint and formattable files for prettier
- On push to `main`: runs the existing `npm run format:check` (full repo)
- If no lintable/formattable files changed, those steps are skipped entirely

## Test plan
- [ ] Verify CI passes on this PR (only the workflow file changed — no lint targets)
- [ ] Verify a future PR touching `src/` gets incremental lint
- [ ] Verify pushes to `main` still run full lint