### PR TITLE
chore: ignore CHANGELOG.md in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ e2e/crds
 e2e/crds/**/*.ts
 e2e/generated
 generated/**/*.ts
+CHANGELOG.md


### PR DESCRIPTION
## Summary
- Adds `CHANGELOG.md` to `.prettierignore` so the `format:check` command no longer fails on the auto-generated changelog from release-please.

## Test plan
- [x] Verified `npx prettier --check CHANGELOG.md` passes with the ignore rule in place