### PR TITLE
docs(adr): propose k8s integration test helpers

### DIFF
--- a/doc/adr/0001-record-architecture-decisions.md
+++ b/doc/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2026-07-22
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/doc/adr/0002-ship-kubernetes-integration-test-helpers.md
+++ b/doc/adr/0002-ship-kubernetes-integration-test-helpers.md
@@ -1,0 +1,104 @@
+# 2. Ship Kubernetes integration test helpers
+
+Date: 2026-07-22
+
+## Status
+
+Proposed
+
+## Context
+
+UDS packages are tested with cluster-native integration packages: typically in a TypeScript project
+under `tests/`, run by Vitest, using `kubernetes-fluent-client` (KFC) against a real k3d cluster
+provisioned by the package task runner (`uds run test:all`).
+
+An audit of two shipped packages (Argo Events, Peat Node Injector) shows duplication:
+
+- A near-identical `waitFor` polling helper.
+- The same ownership label key (`test.defenseunicorns.dev/source`) and exclusive use of KFC
+  `Apply()` (server-side apply) for resource creation.
+- Byte-identical `vitest.config.ts`, and `package.json`/`tsconfig.json`.
+- A repeated catch-and-rethrow diagnostics block wrapping every test body (7 occurrences).
+- Best-effort deletion, pods-by-label waiters, container-presence checks, owned-Deployment
+  lookup/availability/log helpers, condition and CRD waiters, env-based config, and
+  `GenericKind`/`RegisterKind` boilerplate, all duplicated in pattern.
+
+Both packages also share fixable gaps: every API error is retried (RBAC failures burn the full
+timeout instead of failing fast), and ownership labels are stamped but never used for cleanup.
+
+The KFC repository runs its own Vitest-based e2e package against k3d, and `pepr-excellent-examples`
+maintains a third copy of similar patterns, so this is an ecosystem problem. No existing
+TypeScript library covers this gap; the mature analogues are `kubernetes-sigs/e2e-framework` (Go)
+and Chainsaw (declarative YAML, a paradigm the Peat package deliberately migrated away from).
+
+KFC is the shared dependency of each example consumer, and its README already defines the
+package as a fluent client "with some additional logic for" Server Side Apply, Watch retry/signal
+control, and Field Selectors. Test helpers extend that list rather than changing what the package
+is.
+
+Alternatives considered:
+
+- A sibling workspace package in the KFC repo: strongest runtime/test separation, but requires
+  workspace conversion, monorepo release tooling, and a peer-version matrix.
+- A standalone repo: rejected; it recreates the drift and coordination problem at the repo level.
+- Helpers in reference-package: fallback if the subpath fails its adoption criteria.
+
+## Decision
+
+We will ship a runner-neutral test helper module inside `kubernetes-fluent-client`, exposed as two
+subpath exports:
+
+- `kubernetes-fluent-client/test`: the core. `waitFor` with retryable/terminal error
+  classification (401/403/422 abort; 404/409/timeouts/5xx retry) and an `onTimeout` diagnostics
+  hook; `preflight()`; `env()`; `registerCrd()`; `applyWithOwnership()` (default label key
+  `test.defenseunicorns.dev/source`); `deleteIgnoringNotFound()`; optional namespace lifecycle
+  utilities; waiters (`waitForResource`, `waitForPodsByLabel`, `waitForCrdEstablished`,
+  `waitForResourceConditions`, `findDeploymentOwnedBy`, `waitForOwnedDeploymentAvailable`,
+  `tailOwnedDeploymentLogs`); sync predicates (`hasContainer`); composable diagnostics collectors.
+- `kubernetes-fluent-client/test/vitest`: a thin layer. `defineKubernetesTestConfig()` (the
+  packages' current shared config), a preflight setup helper, and sync matchers. `vitest` is an
+  optional peer dependency used only by this entry.
+
+Guardrails: no cluster provisioning; no package-level fixtures or namespace DSL (packages that test in
+an existing package namespace stay first-class); no async polling matchers, custom environments,
+or reporters in v1; no controller-specific logic; cleanup touches only declared or labeled
+resources; the client code never imports from `src/test/` (enforced in CI).
+
+Rollout: (0) exports and build wiring with empty stubs, optional-peer declaration, import-direction
+CI check, artifact size measurement; (1) extract the core and migrate both packages, deleting local
+copies; (2) label-scoped cleanup, opt-in run-ID label values, and migration of KFC's own e2e package
+onto the core; (3) ship the Vitest entry and point `uds-package-test`/reference-package
+scaffolding at it.
+
+## Consequences
+
+Positive:
+
+- Fixes propagate by version bump; the observed `waitFor` drift ends.
+- Test bodies lose the repeated diagnostics boilerplate; RBAC failures fail in seconds.
+- Adoption is an import statement for every existing KFC consumer, and helper and client versions
+  cannot skew (no peer-range matrix exists).
+- The semantic-release pipeline is untouched, and the README change is one new feature-list entry.
+
+Negative:
+
+- Helper changes release the runtime library. Accepted: runtime entry points do not import test
+  code, so runtime consumers see no behavioral change; revisit the sibling-package option if churn
+  becomes disruptive.
+- The published artifact grows by the test subtree; measured in phase 0 against an agreed budget.
+- KFC maintainers take on the helpers' triage and API stability surface; this decision requires
+  their buy-in.
+- Error classification and `onTimeout` are behavior changes riding along with extraction; package
+  migrations must call them out.
+
+Success criteria for continuing past phase 1: a third package adopts with less bespoke glue than
+either example package; migrations delete more code than the subtree adds; a contributor beyond
+the original author lands a change. Revert to blessed copy-paste helpers if packages begin wrapping
+the helpers or single-consumer options.
+
+Open questions for the workshop: subpath naming (`./test` vs `./testing` vs `./e2e`, noting the
+repo's existing `test/` fixtures directory); whether helper-only changes carry a distinct
+conventional-commit scope; default waiter timeouts (the example packages disagree); whether run-ID label
+values are opt-in or default-on; whether runner neutrality is enforced by a no-`vitest`-imports CI
+check or by review; the diagnostics output contract (console vs artifact files); and the artifact
+size budget that would trigger reconsidering a sibling package.

--- a/doc/adr/0002-ship-kubernetes-integration-test-helpers.md
+++ b/doc/adr/0002-ship-kubernetes-integration-test-helpers.md
@@ -19,9 +19,11 @@ An audit of two shipped packages (Argo Events, Peat Node Injector) shows duplica
   `Apply()` (server-side apply) for resource creation.
 - Byte-identical `vitest.config.ts`, and `package.json`/`tsconfig.json`.
 - A repeated catch-and-rethrow diagnostics block wrapping every test body (7 occurrences).
-- Best-effort deletion, pods-by-label waiters, container-presence checks, owned-Deployment
-  lookup/availability/log helpers, condition and CRD waiters, env-based config, and
-  `GenericKind`/`RegisterKind` boilerplate, all duplicated in pattern.
+- Best-effort deletion, pods-by-label waiters, container-presence checks, env-based config, and
+  diagnostics collectors, all duplicated in pattern.
+- Deployment-ownership lookup/availability/log helpers, CRD waiters, and
+  `GenericKind`/`RegisterKind` boilerplate present in Argo Events only; namespace lifecycle
+  utilities present in Peat Node Injector only.
 
 Both packages also share fixable gaps: every API error is retried (RBAC failures burn the full
 timeout instead of failing fast), and ownership labels are stamped but never used for cleanup.
@@ -48,13 +50,14 @@ Alternatives considered:
 We will ship a runner-neutral test helper module inside `kubernetes-fluent-client`, exposed as two
 subpath exports:
 
-- `kubernetes-fluent-client/test`: the core. `waitFor` with retryable/terminal error
-  classification (401/403/422 abort; 404/409/timeouts/5xx retry) and an `onTimeout` diagnostics
-  hook; `preflight()`; `env()`; `registerCrd()`; `applyWithOwnership()` (default label key
-  `test.defenseunicorns.dev/source`); `deleteIgnoringNotFound()`; optional namespace lifecycle
-  utilities; waiters (`waitForResource`, `waitForPodsByLabel`, `waitForCrdEstablished`,
-  `waitForResourceConditions`, `findDeploymentOwnedBy`, `waitForOwnedDeploymentAvailable`,
-  `tailOwnedDeploymentLogs`); sync predicates (`hasContainer`); composable diagnostics collectors.
+- `kubernetes-fluent-client/test`: the core, limited to helpers duplicated in both audited
+  packages. `waitFor` with retryable/terminal error classification (401/403/422 abort;
+  404/409/timeouts/5xx retry) and an `onTimeout` diagnostics hook; `preflight()`; `env()`
+  (including waiter-timeout overrides); `applyWithOwnership()` (default label key
+  `test.defenseunicorns.dev/source`); `deleteIgnoringNotFound()`; waiters (`waitForResource`,
+  `waitForPodsByLabel`); sync predicates (`hasContainer`); composable diagnostics collectors.
+  Helpers present in only one consumer (e.g. deployment-ownership lookup, log tailing, CRD
+  registration and waiters, namespace lifecycle) stay in that consumer until a second case appears.
 - `kubernetes-fluent-client/test/vitest`: a thin layer. `defineKubernetesTestConfig()` (the
   packages' current shared config), a preflight setup helper, and sync matchers. `vitest` is an
   optional peer dependency used only by this entry.
@@ -62,7 +65,10 @@ subpath exports:
 Guardrails: no cluster provisioning; no package-level fixtures or namespace DSL (packages that test in
 an existing package namespace stay first-class); no async polling matchers, custom environments,
 or reporters in v1; no controller-specific logic; cleanup touches only declared or labeled
-resources; the client code never imports from `src/test/` (enforced in CI).
+resources. The client's runtime code never imports from `src/test/` (enforced by a CI lint rule);
+runner neutrality in the core entry is enforced by a separate CI lint rule that rejects
+vitest-specific imports. For external consumers, the `/test` subpath signals test-only use (the
+same convention as `@angular/core/testing`).
 
 Rollout: (0) exports and build wiring with empty stubs, optional-peer declaration, import-direction
 CI check, artifact size measurement; (1) extract the core and migrate both packages, deleting local
@@ -83,8 +89,10 @@ Positive:
 Negative:
 
 - Helper changes release the runtime library. Accepted: runtime entry points do not import test
-  code, so runtime consumers see no behavioral change; revisit the sibling-package option if churn
-  becomes disruptive.
+  code, so runtime consumers see no behavioral change. The initial API surface is deliberately
+  small (only helpers duplicated in both audited packages); additional helpers are promoted when a
+  second consumer appears. Revisit the sibling-package option if churn or surface growth becomes
+  disruptive.
 - The published artifact grows by the test subtree; measured in phase 0 against an agreed budget.
 - KFC maintainers take on the helpers' triage and API stability surface; this decision requires
   their buy-in.
@@ -96,9 +104,12 @@ either example package; migrations delete more code than the subtree adds; a con
 the original author lands a change. Revert to blessed copy-paste helpers if packages begin wrapping
 the helpers or single-consumer options.
 
+Decisions made during review: default waiter timeouts adopt the values from the existing KFC e2e
+suite, documented with rationale, and are overridable via `env()`; runner neutrality in the core
+entry is enforced by a CI lint rule (not left to review).
+
 Open questions for the workshop: subpath naming (`./test` vs `./testing` vs `./e2e`, noting the
 repo's existing `test/` fixtures directory); whether helper-only changes carry a distinct
-conventional-commit scope; default waiter timeouts (the example packages disagree); whether run-ID label
-values are opt-in or default-on; whether runner neutrality is enforced by a no-`vitest`-imports CI
-check or by review; the diagnostics output contract (console vs artifact files); and the artifact
-size budget that would trigger reconsidering a sibling package.
+conventional-commit scope; whether run-ID label values are opt-in or default-on; the diagnostics
+output contract (console vs artifact files); and the artifact size budget that would trigger
+reconsidering a sibling package.


### PR DESCRIPTION
## Description

Adds ADR 0002 proposing that kubernetes-fluent-client ship a runner-neutral
Kubernetes integration test helper module as two subpath exports
(`kubernetes-fluent-client/test` and `kubernetes-fluent-client/test/vitest`).

**Why:** Two UDS packages (Argo Events, Peat Node Injector)
have heavy duplication in their cluster-native integration tests: a
near-identical `waitFor` polling helper, Vitest/TS config files,
repeated diagnostics boilerplate, and duplicated waiter/cleanup/ownership
patterns. KFC's own e2e package and pepr-excellent-examples carry additional 
copies, making this an ecosystem-wide drift problem with no existing TypeScript 
library covering the gap.

**What the ADR covers:**
- The proposed helper API surface (error-classifying `waitFor`, ownership-labeled
  apply, waiters, diagnostics collectors) and a thin optional Vitest layer
- Guardrails: no cluster provisioning, no controller-specific logic, runtime
  code never imports test code (CI-enforced), `vitest` as optional peer dep
- A phased rollout (stubs → extraction/migration → cleanup + KFC e2e migration
  → Vitest entry + scaffolding integration)
- Alternatives considered (sibling workspace package, standalone repo,
  reference-package helpers) and explicit success/revert criteria
- Open questions to resolve (subpath naming, commit scope, default timeouts, 
  diagnostics contract, etc.)

Status is **Proposed**: this PR is intended to anchor the discussion
and gather maintainer buy-in, not to commit to implementation.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed