### PR TITLE
ci: drop Node 20 and matrix e2e across supported versions

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -27,8 +27,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
-          cache-dependency-path: pepr
+          node-version: 24
       - name: "Checkout Repository"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Circular Dependency Check

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,7 @@ jobs:
     name: e2e
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: [22, 24, 26]
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,9 @@ jobs:
   e2e:
     name: e2e
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22, 24, 26]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -28,7 +31,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: "npm"
           cache-dependency-path: kubernetes-fluent-client
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js latest
+      - name: Use Node.js 24
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: latest
+          node-version: 24
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/pexex.yaml
+++ b/.github/workflows/pexex.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "npm"
           cache-dependency-path: kubernetes-fluent-client
 
@@ -102,7 +102,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "npm"
           cache-dependency-path: kubernetes-fluent-client
 
@@ -151,7 +151,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "npm"
           cache-dependency-path: pepr-excellent-examples
 


### PR DESCRIPTION
## Context

Node 20 reached end-of-life in April 2026. The main unit-test matrix in `node.js.yml` and `engines.node` (`>=22.19.0`) already exclude it, but a few CI jobs were still pinned to Node 20 and the e2e suite ran on only a single version. This finishes the removal and aligns the rest of CI on supported versions.

## Changes

- **`pexex.yaml`** (3 jobs) and **`dependency-review.yml`**: `node-version: 20` → `24`
- **`dependency-review.yml`**: removed stale `cache-dependency-path: pepr` — there is no `pepr` directory in this repo (copy-paste leftover from the Pepr repo); the `circular-dependencies` job only runs `npx madge`
- **`e2e.yml`**: the k3d e2e suite now runs across a matrix of `[22, 24, 26]` instead of only Node 22, matching the unit-test matrix so end-to-end behavior is validated on every supported version
- **`node.js.yml`** format job: pinned `latest` → `24` for reproducible runs and toolchain consistency (release/nightlies already use 24)

## Net state of Node support

| Axis | Versions |
|---|---|
| Unit test matrix (`node.js.yml`) | 22, 24, 26 (unchanged) |
| e2e matrix (`e2e.yml`) | 22, 24, 26 (**new** — was 22 only) |
| `engines.node` | `>=22.19.0` (unchanged) |
| Fixed toolchain jobs (release/nightlies/format/pexex/dep-review) | 24 |

## Verification

- Confirmed no `node-version: 20` remains anywhere in `.github/workflows/`
- Stale `cache-dependency-path: pepr` removed
- All edited workflows parse as valid YAML
- CI on this PR exercises the new e2e matrix (3 legs, each spinning up its own k3d cluster)

> [!NOTE]
> The e2e matrix triples e2e runner minutes (a fresh k3d cluster per version). Legs run in parallel so wall-clock is ~unchanged. If cost is a concern, an alternative is matrixing only the boundaries `[22, 26]`.