### PR TITLE
chore(deps): remove unused node-fetch direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@kubernetes/client-node": "1.4.0",
         "http-status-codes": "2.3.0",
         "js-yaml": "5.2.2",
-        "node-fetch": "2.7.0",
         "quicktype-core": "25.0.0",
         "tsx": "4.23.1",
         "undici": "8.7.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@kubernetes/client-node": "1.4.0",
     "http-status-codes": "2.3.0",
     "js-yaml": "5.2.2",
-    "node-fetch": "2.7.0",
     "quicktype-core": "25.0.0",
     "tsx": "4.23.1",
     "undici": "8.7.0",

--- a/src/fluent/utils.test.ts
+++ b/src/fluent/utils.test.ts
@@ -4,9 +4,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PatchStrategy, KubeConfig } from "@kubernetes/client-node";
 import * as fs from "fs";
-import { RequestInit } from "node-fetch";
 import { fetch } from "../fetch.js";
-import { Headers } from "undici";
+import { Headers, HeadersInit, RequestInit } from "undici";
 import { RegisterKind } from "../kinds.js";
 import { GenericClass } from "../types.js";
 import { ClusterRole, Ingress, Pod } from "../upstream.js";

--- a/src/fluent/utils.ts
+++ b/src/fluent/utils.ts
@@ -2,9 +2,8 @@
 // SPDX-FileCopyrightText: 2023-Present The Kubernetes Fluent Client Authors
 
 import { KubeConfig, PatchStrategy } from "@kubernetes/client-node";
-import { RequestInit } from "node-fetch";
 import { URL } from "url";
-import { Agent, Dispatcher } from "undici";
+import { Agent, Dispatcher, RequestInit } from "undici";
 import { Agent as httpsAgent } from "https";
 import { fetch } from "../fetch.js";
 import { modelToGroupVersionKind } from "../kinds.js";
@@ -46,7 +45,7 @@ export async function getHeaders(token?: string | null): Promise<Record<string, 
 /**
  * Get the agent for a request
  *
- * @param opts - the request options from node-fetch
+ * @param opts - the request options from undici
  * @returns the agent for undici
  */
 export function getHTTPSAgent(opts: RequestInit): Dispatcher | undefined {
@@ -160,7 +159,7 @@ export function pathBuilder<T extends GenericClass>(
  * A few notes:
  * - The kubeconfig is loaded from the default location, and can check for in-cluster config
  * - We have to create an agent to handle the TLS connection (for the custom CA + mTLS in some cases)
- * - The K8s lib uses request instead of node-fetch today so the object is slightly different
+ * - The K8s lib uses request instead of undici today so the object is slightly different
  *
  * @param method - the HTTP method to use
  * @returns the fetch options and server URL
@@ -182,8 +181,7 @@ export async function k8sCfg(method: FetchMethods): K8sConfigPromise {
   const headersMap = symbols
     .map(symbol => Object.getOwnPropertyDescriptor(opts.headers, symbol)?.value)
     .find(value => typeof value === "object" && value !== null) as
-    | Record<string, string[]>
-    | undefined;
+    Record<string, string[]> | undefined;
 
   // Extract the Authorization header
   const extractedHeaders: Record<string, string | undefined> = {

--- a/src/fluent/watch.test.ts
+++ b/src/fluent/watch.test.ts
@@ -2,9 +2,8 @@
 
 import { KubeConfig } from "@kubernetes/client-node";
 import type { RequestOptions } from "https";
-import type { HeadersInit, RequestInit } from "node-fetch";
 import { PassThrough } from "stream";
-import { Interceptable, MockAgent, setGlobalDispatcher } from "undici";
+import { HeadersInit, Interceptable, MockAgent, RequestInit, setGlobalDispatcher } from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WatchEvent, kind } from "../index.js";
 import { K8s } from "./index.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import * as kind from "./upstream.js";
 /** kind is a collection of K8s types to be used within a K8s call: `K8s(kind.Secret).Apply({})`. */
 export { kind };
 
-// Export the node-fetch wrapper
+// Export the fetch wrapper
 export { fetch } from "./fetch.js";
 
 // Export the HTTP status codes


### PR DESCRIPTION
## Summary

`node-fetch` was a direct dependency but was imported **only for its TypeScript types** (`RequestInit`, `HeadersInit`) — never used at runtime. All actual HTTP already goes through `undici` (`src/fetch.ts`, `src/fluent/watch.ts`), which exports those same types. This removes `node-fetch` as a direct dependency and sources the types from `undici` instead.

It remains available transitively via `@kubernetes/client-node`, so nothing is lost from the dependency tree — this only trims our declared surface.

## Changes
- `src/fluent/utils.ts` — `RequestInit` now from `undici`
- `src/fluent/utils.test.ts` — `RequestInit` + `HeadersInit` from `undici` (`HeadersInit` was previously an implicit global)
- `src/fluent/watch.test.ts` — `HeadersInit` + `RequestInit` from `undici`
- `src/index.ts` + `src/fluent/utils.ts` — updated stale `node-fetch` doc comments
- `package.json` / `package-lock.json` — dropped the direct `node-fetch` entry

## Verification
- `tsc --noEmit` — passes (undici types are structurally compatible)
- `npm test` — 207 tests / 10 files passed
- `npm run format:check` (eslint + prettier) — passes
- No runtime/behavior change