### PR TITLE
fix(ci): e2e flake diagnostics

### DIFF
--- a/e2e/main.e2e.test.ts
+++ b/e2e/main.e2e.test.ts
@@ -6,6 +6,8 @@ import { V1APIGroup } from "@kubernetes/client-node";
 import { beforeEach } from "node:test";
 
 const namespace = `e2e-tests`;
+const e2eFetchAttempts = 4;
+const e2eFetchBackoffMs = 250;
 
 describe("KFC e2e test", () => {
   beforeAll(async () => {
@@ -381,31 +383,128 @@ it("kfc fetch", async () => {
   const jsonURL = "https://api.github.com/repositories/1";
   const stringURL = "https://api.github.com/octocat";
 
-  interface GHRepo {
+  interface TestRepo {
     id: number;
     name: string;
     full_name: string;
   }
-  // string
-  try {
-    const { data, ok } = await fetch(stringURL);
-    expect(ok).toBe(true);
-    expect(data).toBeDefined();
-    expect(data).toContain("MMMMMMMMMMMMM");
-  } catch (e) {
-    expect(e).toBeUndefined();
+
+  const stringResponse = await fetchWithE2EDiagnostics<string>(stringURL);
+  expect(stringResponse.ok).toBe(true);
+  expect(stringResponse.data).toBeDefined();
+  expect(stringResponse.data).toContain("MMMMMMMMMMMMM");
+
+  const jsonResponse = await fetchWithE2EDiagnostics<TestRepo>(jsonURL);
+  expect(jsonResponse.ok).toBe(true);
+  expect(jsonResponse.data).toBeDefined();
+  expect(jsonResponse.data.id).toBe(1);
+});
+
+/**
+ * Fetch an external e2e resource with short retries and actionable diagnostics.
+ *
+ * @param url - URL to fetch
+ * @returns successful KFC fetch response
+ */
+async function fetchWithE2EDiagnostics<T>(
+  url: string,
+): Promise<Awaited<ReturnType<typeof fetch<T>>>> {
+  let lastResponse: Awaited<ReturnType<typeof fetch<T>>> | undefined;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= e2eFetchAttempts; attempt++) {
+    try {
+      const response = await fetch<T>(url);
+      if (response.ok) {
+        return response;
+      }
+
+      lastResponse = response;
+      logFetchFailure(url, attempt, response);
+    } catch (error) {
+      lastError = error;
+      logFetchFailure(url, attempt, undefined, error);
+    }
+
+    if (attempt < e2eFetchAttempts) {
+      await sleepMilliseconds(e2eFetchBackoffMs);
+    }
   }
 
-  // JSON payload
-  try {
-    const { data, ok } = await fetch<GHRepo>(jsonURL);
-    expect(ok).toBe(true);
-    expect(data).toBeDefined();
-    expect(data.id).toBe(1);
-  } catch (e) {
-    expect(e).toBeUndefined();
+  throw new Error(
+    `Failed to fetch ${url} after ${e2eFetchAttempts} attempts. ${fetchFailureDetails(
+      lastResponse,
+      lastError,
+    )}`,
+  );
+}
+
+/**
+ * Log a failed external e2e fetch attempt.
+ *
+ * @param url - URL that failed
+ * @param attempt - one-based attempt number
+ * @param response - failed KFC fetch response
+ * @param error - thrown error, if any
+ */
+function logFetchFailure<T>(
+  url: string,
+  attempt: number,
+  response?: Awaited<ReturnType<typeof fetch<T>>>,
+  error?: unknown,
+): void {
+  console.warn(
+    `[e2e fetch] ${url} attempt ${attempt}/${e2eFetchAttempts} failed. ${fetchFailureDetails(
+      response,
+      error,
+    )}`,
+  );
+}
+
+/**
+ * Format fetch failure context for e2e logs.
+ *
+ * @param response - failed KFC fetch response
+ * @param error - thrown error, if any
+ * @returns concise failure context
+ */
+function fetchFailureDetails<T>(
+  response?: Awaited<ReturnType<typeof fetch<T>>>,
+  error?: unknown,
+): string {
+  const responseDetails = response
+    ? `ok=${response.ok} status=${response.status} statusText=${response.statusText}`
+    : "no response";
+  const responseError = response?.e ? ` responseError=${errorDetails(response.e)}` : "";
+  const thrownError = error ? ` thrownError=${errorDetails(error)}` : "";
+
+  return `${responseDetails}${responseError}${thrownError}`;
+}
+
+/**
+ * Format an unknown error value.
+ *
+ * @param error - error-like value
+ * @returns error message
+ */
+function errorDetails(error: unknown): string {
+  if (error instanceof Error) {
+    const cause = error.cause ? ` cause=${String(error.cause)}` : "";
+    return `${error.name}: ${error.message}${cause}`;
   }
-});
+
+  return String(error);
+}
+
+/**
+ * Sleep for a fixed number of milliseconds.
+ *
+ * @param milliseconds - milliseconds to sleep
+ * @returns Promise<void>
+ */
+function sleepMilliseconds(milliseconds: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
 
 /**
  * sleep for a given number of seconds

--- a/e2e/watch.e2e.test.ts
+++ b/e2e/watch.e2e.test.ts
@@ -1,9 +1,146 @@
 import { GenericClass, K8s, kind, KubernetesObject } from "../src";
 import { beforeAll, describe, expect, it } from "vitest";
-import { execSync } from "child_process";
 import { WatchPhase } from "../src/fluent/shared-types.js";
 import { WatchEvent } from "../src";
+import type { EventEmitter } from "node:events";
 const namespace = `kfc-watch`;
+const shortTimeoutMs = 5000;
+const recoveryTimeoutMs = 15000;
+
+/**
+ * Resolve after an event has fired a target number of times.
+ *
+ * @param events - event source
+ * @param event - event name
+ * @param targetCount - number of events to observe
+ * @returns promise that resolves when the target count is reached
+ */
+function waitForEventCount(
+  events: EventEmitter,
+  event: string,
+  targetCount: number,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let count = 0;
+    const timeout = setTimeout(() => {
+      events.off(event, onEvent);
+      reject(new Error(`Timed out waiting for ${targetCount} ${event} events`));
+    }, recoveryTimeoutMs);
+
+    const onEvent = () => {
+      count++;
+      if (count >= targetCount) {
+        clearTimeout(timeout);
+        events.off(event, onEvent);
+        resolve();
+      }
+    };
+
+    events.on(event, onEvent);
+  });
+}
+
+/**
+ * Wait for the watcher to see the pod, emit reconnect, then establish a replacement watch.
+ *
+ * @param events - watcher event source
+ * @param seenPodPromise - resolves after callback sees the listed pod
+ * @returns promise that resolves after reconnect recovery is proven
+ */
+function watcherRecoveryPromise(events: EventEmitter, seenPodPromise: Promise<void>) {
+  const reconnectPromise = eventPromise<number>(
+    events,
+    WatchEvent.RECONNECT,
+    recoveryTimeoutMs,
+  ).then(num => {
+    expect(num).toBe(1);
+  });
+  const recoveredConnectPromise = waitForEventCount(events, WatchEvent.CONNECT, 2);
+
+  return Promise.all([
+    withTimeout(seenPodPromise, "callback to see pod", shortTimeoutMs),
+    reconnectPromise,
+    recoveredConnectPromise,
+  ]);
+}
+
+/**
+ * Reject when the watcher emits any failure event relevant to this test.
+ *
+ * @param events - watcher event source
+ * @returns promise that rejects with the emitted failure
+ */
+function watcherFailurePromise(events: EventEmitter): Promise<never> {
+  return Promise.race([
+    onceEvent<Error>(events, WatchEvent.DATA_ERROR).then(err => {
+      throw err;
+    }),
+    onceEvent<Error>(events, WatchEvent.LIST_ERROR).then(err => {
+      throw err;
+    }),
+    onceEvent<Error>(events, WatchEvent.WATCH_ERROR).then(err => {
+      throw err;
+    }),
+    onceEvent<Error>(events, WatchEvent.NETWORK_ERROR).then(err => {
+      throw err;
+    }),
+  ]);
+}
+
+/**
+ * Resolve when an event fires, or reject if it does not fire before the timeout.
+ *
+ * @param events - event source
+ * @param event - event name
+ * @param timeoutMs - timeout in milliseconds
+ * @returns first event argument
+ */
+function eventPromise<T>(events: EventEmitter, event: string, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      events.off(event, onEvent);
+      reject(new Error(`Timed out waiting for ${event}`));
+    }, timeoutMs);
+
+    const onEvent = (value: T) => {
+      clearTimeout(timeout);
+      resolve(value);
+    };
+
+    events.once(event, onEvent);
+  });
+}
+
+/**
+ * Add a timeout to an existing promise.
+ *
+ * @param promise - promise to bound
+ * @param label - label used in timeout errors
+ * @param timeoutMs - timeout in milliseconds
+ * @returns original promise result
+ */
+function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), timeoutMs);
+    }),
+  ]);
+}
+
+/**
+ * Resolve when an event is emitted.
+ *
+ * @param events - event source
+ * @param event - event name
+ * @returns emitted event payload
+ */
+function onceEvent<T>(events: EventEmitter, event: string): Promise<T> {
+  return new Promise<T>(resolve => {
+    events.once(event, resolve);
+  });
+}
+
 describe("watcher e2e", () => {
   beforeAll(async () => {
     try {
@@ -27,6 +164,35 @@ describe("watcher e2e", () => {
       expect(e).toBeUndefined();
     }
   }, 80000);
+
+  it("should handle the RECONNECT event", async () => {
+    let seenPodResolve!: () => void;
+    const seenPodPromise = new Promise<void>(resolve => {
+      seenPodResolve = resolve;
+    });
+    const watcher = K8s(kind.Pod)
+      .InNamespace(namespace)
+      .Watch(
+        po => {
+          expect(po.metadata!.name).toBe(namespace);
+          seenPodResolve();
+        },
+        {
+          resyncDelaySec: 0.01,
+          lastSeenLimitSeconds: 0.01,
+        },
+      );
+
+    try {
+      const watcherErrorPromise = watcherFailurePromise(watcher.events);
+      const recoveryPromise = watcherRecoveryPromise(watcher.events, seenPodPromise);
+
+      void watcher.start();
+      await Promise.race([recoveryPromise, watcherErrorPromise]);
+    } finally {
+      watcher.close();
+    }
+  }, 90000);
 
   it("should watch named resources", () => {
     return new Promise<void>(resolve => {
@@ -73,25 +239,6 @@ describe("watcher e2e", () => {
     await connectPromise;
     watcher.close();
   });
-
-  it("should handle the RECONNECT event", () => {
-    return new Promise<void>(resolve => {
-      const watcher = K8s(kind.Pod)
-        .InNamespace(namespace)
-        .Watch(po => {
-          expect(po.metadata!.name).toBe(namespace);
-        });
-      void watcher.start();
-
-      watcher.events.on(WatchEvent.RECONNECT, num => {
-        expect(num).toBe(1);
-      });
-      execSync(`k3d cluster stop kfc-dev`, { stdio: "inherit" });
-      execSync(`k3d cluster start kfc-dev`, { stdio: "inherit" });
-      watcher.close();
-      resolve();
-    });
-  }, 90000);
 
   it("should handle the DATA event", () => {
     return new Promise<void>(resolve => {

--- a/e2e/watch.e2e.test.ts
+++ b/e2e/watch.e2e.test.ts
@@ -4,7 +4,6 @@ import { WatchPhase } from "../src/fluent/shared-types.js";
 import { WatchEvent } from "../src";
 import type { EventEmitter } from "node:events";
 const namespace = `kfc-watch`;
-const shortTimeoutMs = 5000;
 const recoveryTimeoutMs = 15000;
 
 /**
@@ -101,7 +100,7 @@ function watcherRecoveryPromise(events: EventEmitter, seenPodPromise: Promise<vo
     events.on(WatchEvent.CONNECT, onConnect);
     events.on(WatchEvent.RECONNECT, onReconnect);
 
-    withTimeout(seenPodPromise, "callback to see pod", shortTimeoutMs)
+    withTimeout(seenPodPromise, "callback to see pod", recoveryTimeoutMs)
       .then(() => {
         podSeen = true;
       })

--- a/e2e/watch.e2e.test.ts
+++ b/e2e/watch.e2e.test.ts
@@ -8,39 +8,6 @@ const shortTimeoutMs = 5000;
 const recoveryTimeoutMs = 15000;
 
 /**
- * Resolve after an event has fired a target number of times.
- *
- * @param events - event source
- * @param event - event name
- * @param targetCount - number of events to observe
- * @returns promise that resolves when the target count is reached
- */
-function waitForEventCount(
-  events: EventEmitter,
-  event: string,
-  targetCount: number,
-): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    let count = 0;
-    const timeout = setTimeout(() => {
-      events.off(event, onEvent);
-      reject(new Error(`Timed out waiting for ${targetCount} ${event} events`));
-    }, recoveryTimeoutMs);
-
-    const onEvent = () => {
-      count++;
-      if (count >= targetCount) {
-        clearTimeout(timeout);
-        events.off(event, onEvent);
-        resolve();
-      }
-    };
-
-    events.on(event, onEvent);
-  });
-}
-
-/**
  * Wait for the watcher to see the pod, emit reconnect, then establish a replacement watch.
  *
  * @param events - watcher event source
@@ -48,20 +15,98 @@ function waitForEventCount(
  * @returns promise that resolves after reconnect recovery is proven
  */
 function watcherRecoveryPromise(events: EventEmitter, seenPodPromise: Promise<void>) {
-  const reconnectPromise = eventPromise<number>(
-    events,
-    WatchEvent.RECONNECT,
-    recoveryTimeoutMs,
-  ).then(num => {
-    expect(num).toBe(1);
-  });
-  const recoveredConnectPromise = waitForEventCount(events, WatchEvent.CONNECT, 2);
+  return new Promise<void>((resolve, reject) => {
+    let initialConnectSeen = false;
+    let podSeen = false;
+    let reconnectSeen = false;
+    let settled = false;
 
-  return Promise.all([
-    withTimeout(seenPodPromise, "callback to see pod", shortTimeoutMs),
-    reconnectPromise,
-    recoveredConnectPromise,
-  ]);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      events.off(WatchEvent.CONNECT, onConnect);
+      events.off(WatchEvent.RECONNECT, onReconnect);
+    };
+
+    const finish = (err?: unknown) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve();
+    };
+
+    const failOutOfOrder = (message: string) => {
+      finish(new Error(`Watcher recovery events out of order: ${message}`));
+    };
+
+    const timeout = setTimeout(() => {
+      const state = [
+        initialConnectSeen && "initial CONNECT",
+        podSeen && "pod callback",
+        reconnectSeen && "RECONNECT",
+      ]
+        .filter(Boolean)
+        .join(", ");
+
+      finish(
+        new Error(
+          `Timed out waiting for watcher lifecycle; observed ${state || "no recovery events"}`,
+        ),
+      );
+    }, recoveryTimeoutMs);
+
+    const onConnect = () => {
+      if (!initialConnectSeen) {
+        initialConnectSeen = true;
+        return;
+      }
+
+      if (!reconnectSeen) {
+        failOutOfOrder("replacement CONNECT occurred before RECONNECT");
+        return;
+      }
+
+      finish();
+    };
+
+    const onReconnect = (num: number) => {
+      try {
+        expect(num).toBe(1);
+      } catch (err) {
+        finish(err);
+        return;
+      }
+
+      if (!initialConnectSeen) {
+        failOutOfOrder("RECONNECT occurred before initial CONNECT");
+        return;
+      }
+
+      if (!podSeen) {
+        failOutOfOrder("RECONNECT occurred before callback saw pod");
+        return;
+      }
+
+      reconnectSeen = true;
+    };
+
+    events.on(WatchEvent.CONNECT, onConnect);
+    events.on(WatchEvent.RECONNECT, onReconnect);
+
+    withTimeout(seenPodPromise, "callback to see pod", shortTimeoutMs)
+      .then(() => {
+        podSeen = true;
+      })
+      .catch(finish);
+  });
 }
 
 /**
@@ -85,30 +130,6 @@ function watcherFailurePromise(events: EventEmitter): Promise<never> {
       throw err;
     }),
   ]);
-}
-
-/**
- * Resolve when an event fires, or reject if it does not fire before the timeout.
- *
- * @param events - event source
- * @param event - event name
- * @param timeoutMs - timeout in milliseconds
- * @returns first event argument
- */
-function eventPromise<T>(events: EventEmitter, event: string, timeoutMs: number): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      events.off(event, onEvent);
-      reject(new Error(`Timed out waiting for ${event}`));
-    }, timeoutMs);
-
-    const onEvent = (value: T) => {
-      clearTimeout(timeout);
-      resolve(value);
-    };
-
-    events.once(event, onEvent);
-  });
 }
 
 /**


### PR DESCRIPTION
## Description

Hardens the flaky e2e coverage without reintroducing shared cluster lifecycle disruption.

- Restores `kfc fetch` to the original GitHub resources and wraps those external calls in test-only retry/diagnostic logging.
- Removes broad `try/catch expect(e).toBeUndefined()` handling from the fetch assertions so final failures include clearer context.
- Reworks the watch reconnect e2e to run in the normal watcher lifecycle and prove recovery by observing the pod callback, `RECONNECT`, and a second `CONNECT` without stopping or starting the shared k3d cluster.

## Related Issue

Relates to merge queue e2e flakes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed

## Validation

- `npx prettier e2e/main.e2e.test.ts e2e/watch.e2e.test.ts e2e/tsconfig.json --check`
- `npx eslint --max-warnings 37 e2e/main.e2e.test.ts e2e/watch.e2e.test.ts`
- `npx vitest run e2e/main.e2e.test.ts -t "kfc fetch"`
- `npm run build`