### PR TITLE
chore(deps): group CodeQL action Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,3 +67,8 @@ updates:
       interval: daily
     cooldown:
       default-days: 7
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action"
+          - "github/codeql-action/*"


### PR DESCRIPTION
## Description

Adds a Dependabot `github-actions` group for the `github/codeql-action` family so updates for `init`, `analyze`, and `upload-sarif` are raised together instead of as separate noisy PRs.

This follows GitHub's Dependabot `groups` configuration for matching dependencies by `patterns`.

Validation:

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "dependabot.yml YAML OK"'`
- Commit hook ran `prettier --write` for `.github/dependabot.yml` during commit and reported the file unchanged.

## Related Issue

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
