### PR TITLE
fix: export fluent watch types from package root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,14 +15,15 @@ export { fetch } from "./fetch.js";
 // Export the HTTP status codes
 export { StatusCodes as fetchStatus } from "http-status-codes";
 
-// Export the Watch Config and Event types
-export { WatchCfg, WatchEvent } from "./fluent/watch.js";
+// Export watch types used by clients that reconcile Kubernetes resources.
+export { WatchCfg, WatchEvent, Watcher } from "./fluent/watch.js";
+export { WatchPhase } from "./fluent/shared-types.js";
 
 // Export the fluent API entrypoint
 export { K8s } from "./fluent/index.js";
 
 // Export types used in the fluent API's public method signatures
-export type { Operation, PartialDeep } from "./fluent/types.js";
+export type { K8sInit, Operation, PartialDeep, WatcherType } from "./fluent/types.js";
 
 // Export helpers for working with K8s types
 export { RegisterKind, modelToGroupVersionKind } from "./kinds.js";

--- a/src/test/verify-package.test.ts
+++ b/src/test/verify-package.test.ts
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026-Present The Kubernetes Fluent Client Authors
 
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -74,17 +74,10 @@ describe("published package", () => {
       ["install", "--ignore-scripts", "--package-lock=false", "--cache", npmCache, tarballPath],
       { cwd: consumerRoot, encoding: "utf8" },
     );
-    execFileSync(
-      "npm",
-      [
-        "install",
-        "--ignore-scripts",
-        "--package-lock=false",
-        "--cache",
-        npmCache,
-        `vitest@${packageJson.peerDependencies.vitest}`,
-      ],
-      { cwd: consumerRoot, encoding: "utf8" },
+    await symlink(
+      join(packageRoot, "node_modules", "vitest"),
+      join(consumerRoot, "node_modules", "vitest"),
+      "dir",
     );
   }, 60_000);
 

--- a/src/test/verify-package.test.ts
+++ b/src/test/verify-package.test.ts
@@ -64,10 +64,12 @@ describe("published package", () => {
       `${packageJson.name}/test/vitest/setup`,
       `${packageJson.name}/dist/fetch.js`,
     ];
-    const [, , vitestConfigEntry, vitestSetupEntry] = (await Promise.all(
+    const [rootEntry, , vitestConfigEntry, vitestSetupEntry] = (await Promise.all(
       entries.map(entry => import(entry)),
     )) as Record<string, unknown>[];
 
+    expect(rootEntry.WatchPhase).toMatchObject({ Added: "ADDED" });
+    expect(rootEntry.Watcher).toBeTypeOf("function");
     expect(vitestConfigEntry.defineKubernetesTestConfig).toBeTypeOf("function");
     expect(vitestConfigEntry).not.toHaveProperty("setupKubernetesPreflight");
     expect(vitestSetupEntry.setupKubernetesPreflight).toBeTypeOf("function");
@@ -78,18 +80,30 @@ describe("published package", () => {
     expect(packedFiles).toContain(file);
   });
 
-  it("compiles a consumer's Vitest configuration", async () => {
+  it("compiles a NodeNext consumer using the public fluent API", async () => {
     const consumerRoot = await mkdtemp(join(tmpdir(), "kfc-consumer-check-"));
 
     try {
       const nodeModules = join(consumerRoot, "node_modules");
       const consumerConfig = join(consumerRoot, "vitest.config.ts");
+      const consumerSource = join(consumerRoot, "consumer.ts");
       await mkdir(nodeModules);
       await symlink(packageRoot, join(nodeModules, packageJson.name), "dir");
       await writeFile(
         consumerConfig,
         'import { defineKubernetesTestConfig } from "kubernetes-fluent-client/test/vitest";\n' +
           "export default defineKubernetesTestConfig();\n",
+      );
+      await writeFile(
+        consumerSource,
+        'import { WatchEvent, WatchPhase, Watcher, type K8sInit, type KubernetesListObject, type WatchCfg, type WatcherType } from "kubernetes-fluent-client";\n' +
+          "const phase = WatchPhase.Added;\n" +
+          "const event = WatchEvent.CONNECT;\n" +
+          "void phase;\n" +
+          "void event;\n" +
+          "void Watcher;\n" +
+          "type PublicFluentTypes = [K8sInit<any, any>, KubernetesListObject<any>, WatchCfg, WatcherType<any>];\n" +
+          "void (null as unknown as PublicFluentTypes);\n",
       );
       execFileSync(
         join(packageRoot, "node_modules", ".bin", "tsc"),
@@ -104,6 +118,7 @@ describe("published package", () => {
           "--moduleResolution",
           "NodeNext",
           consumerConfig,
+          consumerSource,
         ],
         { cwd: consumerRoot, encoding: "utf8" },
       );

--- a/src/test/verify-package.test.ts
+++ b/src/test/verify-package.test.ts
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026-Present The Kubernetes Fluent Client Authors
 
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 interface PackResult {
+  filename: string;
   files: { path: string }[];
 }
 
@@ -31,24 +32,60 @@ const requiredFiles = [
 ];
 
 describe("published package", () => {
-  let npmCache: string | undefined;
+  let packageWorkspace: string | undefined;
+  let consumerRoot: string;
+  let npmCache: string;
+  let tarballPath: string;
   let packResult: PackResult;
 
   beforeAll(async () => {
-    npmCache = await mkdtemp(join(tmpdir(), "kfc-package-check-"));
+    packageWorkspace = await mkdtemp(join(tmpdir(), "kfc-package-check-"));
+    consumerRoot = join(packageWorkspace, "consumer");
+    npmCache = join(packageWorkspace, "npm-cache");
+    const packDestination = join(packageWorkspace, "pack");
+    await mkdir(packDestination);
     [packResult] = JSON.parse(
       execFileSync(
         "npm",
-        ["pack", "--dry-run", "--ignore-scripts", "--cache", npmCache, "--json"],
+        [
+          "pack",
+          "--ignore-scripts",
+          "--cache",
+          npmCache,
+          "--json",
+          "--pack-destination",
+          packDestination,
+        ],
         {
+          cwd: packageRoot,
           encoding: "utf8",
         },
       ),
     ) as PackResult[];
+    tarballPath = join(packDestination, packResult.filename);
+
+    await mkdir(consumerRoot);
+    await writeFile(
+      join(consumerRoot, "package.json"),
+      JSON.stringify({ private: true, type: "module" }),
+    );
+    execFileSync(
+      "npm",
+      [
+        "install",
+        "--ignore-scripts",
+        "--package-lock=false",
+        "--cache",
+        npmCache,
+        tarballPath,
+        `vitest@${packageJson.peerDependencies.vitest}`,
+      ],
+      { cwd: consumerRoot, encoding: "utf8" },
+    );
   });
 
   afterAll(async () => {
-    if (npmCache) await rm(npmCache, { recursive: true });
+    if (packageWorkspace) await rm(packageWorkspace, { recursive: true, force: true });
   });
 
   it("declares Vitest 4 as an optional peer dependency", () => {
@@ -57,22 +94,29 @@ describe("published package", () => {
   });
 
   it("loads every intentional public entry point and preserves existing deep imports", async () => {
-    const entries = [
-      packageJson.name,
-      `${packageJson.name}/test`,
-      `${packageJson.name}/test/vitest`,
-      `${packageJson.name}/test/vitest/setup`,
-      `${packageJson.name}/dist/fetch.js`,
-    ];
-    const [rootEntry, , vitestConfigEntry, vitestSetupEntry] = (await Promise.all(
-      entries.map(entry => import(entry)),
-    )) as Record<string, unknown>[];
+    const output = execFileSync(
+      "node",
+      [
+        "--input-type=module",
+        "--eval",
+        `
+          import * as rootEntry from ${JSON.stringify(packageJson.name)};
+          import ${JSON.stringify(`${packageJson.name}/test`)};
+          import * as vitestConfigEntry from ${JSON.stringify(`${packageJson.name}/test/vitest`)};
+          import * as vitestSetupEntry from ${JSON.stringify(`${packageJson.name}/test/vitest/setup`)};
+          import ${JSON.stringify(`${packageJson.name}/dist/fetch.js`)};
 
-    expect(rootEntry.WatchPhase).toMatchObject({ Added: "ADDED" });
-    expect(rootEntry.Watcher).toBeTypeOf("function");
-    expect(vitestConfigEntry.defineKubernetesTestConfig).toBeTypeOf("function");
-    expect(vitestConfigEntry).not.toHaveProperty("setupKubernetesPreflight");
-    expect(vitestSetupEntry.setupKubernetesPreflight).toBeTypeOf("function");
+          if (rootEntry.WatchPhase.Added !== "ADDED") throw new Error("WatchPhase is unavailable");
+          if (typeof rootEntry.Watcher !== "function") throw new Error("Watcher is unavailable");
+          if (typeof vitestConfigEntry.defineKubernetesTestConfig !== "function") throw new Error("Vitest config helper is unavailable");
+          if ("setupKubernetesPreflight" in vitestConfigEntry) throw new Error("Vitest config entry exports setup helpers");
+          if (typeof vitestSetupEntry.setupKubernetesPreflight !== "function") throw new Error("Vitest setup helper is unavailable");
+        `,
+      ],
+      { cwd: consumerRoot, encoding: "utf8" },
+    );
+
+    expect(output).toBe("");
   });
 
   it.each(requiredFiles)("includes %s", file => {
@@ -81,50 +125,41 @@ describe("published package", () => {
   });
 
   it("compiles a NodeNext consumer using the public fluent API", async () => {
-    const consumerRoot = await mkdtemp(join(tmpdir(), "kfc-consumer-check-"));
-
-    try {
-      const nodeModules = join(consumerRoot, "node_modules");
-      const consumerConfig = join(consumerRoot, "vitest.config.ts");
-      const consumerSource = join(consumerRoot, "consumer.ts");
-      await mkdir(nodeModules);
-      await symlink(packageRoot, join(nodeModules, packageJson.name), "dir");
-      await writeFile(
+    const consumerConfig = join(consumerRoot, "vitest.config.ts");
+    const consumerSource = join(consumerRoot, "consumer.ts");
+    await writeFile(
+      consumerConfig,
+      'import { defineKubernetesTestConfig } from "kubernetes-fluent-client/test/vitest";\n' +
+        "export default defineKubernetesTestConfig();\n",
+    );
+    await writeFile(
+      consumerSource,
+      'import { WatchEvent, WatchPhase, Watcher, type K8sInit, type KubernetesListObject, type WatchCfg, type WatcherType } from "kubernetes-fluent-client";\n' +
+        "const phase = WatchPhase.Added;\n" +
+        "const event = WatchEvent.CONNECT;\n" +
+        "void phase;\n" +
+        "void event;\n" +
+        "void Watcher;\n" +
+        "type PublicFluentTypes = [K8sInit<any, any>, KubernetesListObject<any>, WatchCfg, WatcherType<any>];\n" +
+        "void (null as unknown as PublicFluentTypes);\n",
+    );
+    execFileSync(
+      join(packageRoot, "node_modules", ".bin", "tsc"),
+      [
+        "--noEmit",
+        "--strict",
+        "--skipLibCheck",
+        "--target",
+        "ES2022",
+        "--module",
+        "NodeNext",
+        "--moduleResolution",
+        "NodeNext",
         consumerConfig,
-        'import { defineKubernetesTestConfig } from "kubernetes-fluent-client/test/vitest";\n' +
-          "export default defineKubernetesTestConfig();\n",
-      );
-      await writeFile(
         consumerSource,
-        'import { WatchEvent, WatchPhase, Watcher, type K8sInit, type KubernetesListObject, type WatchCfg, type WatcherType } from "kubernetes-fluent-client";\n' +
-          "const phase = WatchPhase.Added;\n" +
-          "const event = WatchEvent.CONNECT;\n" +
-          "void phase;\n" +
-          "void event;\n" +
-          "void Watcher;\n" +
-          "type PublicFluentTypes = [K8sInit<any, any>, KubernetesListObject<any>, WatchCfg, WatcherType<any>];\n" +
-          "void (null as unknown as PublicFluentTypes);\n",
-      );
-      execFileSync(
-        join(packageRoot, "node_modules", ".bin", "tsc"),
-        [
-          "--noEmit",
-          "--strict",
-          "--skipLibCheck",
-          "--target",
-          "ES2022",
-          "--module",
-          "NodeNext",
-          "--moduleResolution",
-          "NodeNext",
-          consumerConfig,
-          consumerSource,
-        ],
-        { cwd: consumerRoot, encoding: "utf8" },
-      );
-    } finally {
-      await rm(consumerRoot, { recursive: true });
-    }
+      ],
+      { cwd: consumerRoot, encoding: "utf8" },
+    );
   });
 
   it("includes files only from intentional package paths", () => {

--- a/src/test/verify-package.test.ts
+++ b/src/test/verify-package.test.ts
@@ -71,18 +71,22 @@ describe("published package", () => {
     );
     execFileSync(
       "npm",
+      ["install", "--ignore-scripts", "--package-lock=false", "--cache", npmCache, tarballPath],
+      { cwd: consumerRoot, encoding: "utf8" },
+    );
+    execFileSync(
+      "npm",
       [
         "install",
         "--ignore-scripts",
         "--package-lock=false",
         "--cache",
         npmCache,
-        tarballPath,
         `vitest@${packageJson.peerDependencies.vitest}`,
       ],
       { cwd: consumerRoot, encoding: "utf8" },
     );
-  });
+  }, 60_000);
 
   afterAll(async () => {
     if (packageWorkspace) await rm(packageWorkspace, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- expose `WatchPhase`, `Watcher`, `WatcherType`, and `K8sInit` from the package root
- verify the published artifact as a real NodeNext consumer: create an `npm pack` tarball, install that archive into a disposable project with an isolated npm cache, and load every intentional public runtime entry point there
- compile the public fluent API fixture against the installed archive; link the repository's optional Vitest peer into the disposable consumer only to exercise the `test/vitest` entry point without invoking npm's failing optional-peer resolver path

## Verification
- `npm exec vitest -- run src/test/verify-package.test.ts`
- `npm test` (19 files / 285 tests)
- targeted ESLint, Prettier, and `git diff --check`