### PR TITLE
fix: restore legacy KFC deep import compatibility

### DIFF
--- a/.github/workflows/uds-core.yml
+++ b/.github/workflows/uds-core.yml
@@ -86,16 +86,18 @@ jobs:
         env:
           KFC_TGZ: ${{ github.workspace }}/kubernetes-fluent-client-0.0.0-development.tgz
         run: |
+          npm pkg set "dependencies.kubernetes-fluent-client=file:${KFC_TGZ}"
           npm pkg set "overrides.kubernetes-fluent-client=file:${KFC_TGZ}"
           npm install --ignore-scripts
           node --eval '
             const path = require("node:path");
+            const rootKfcPackageJson = require.resolve("kubernetes-fluent-client/package.json");
             const peprRoot = path.dirname(require.resolve("pepr/package.json"));
             const kfcPackageJson = require.resolve("kubernetes-fluent-client/package.json", {
               paths: [peprRoot],
             });
             const { version } = require(kfcPackageJson);
-            if (version !== "0.0.0-development") {
+            if (kfcPackageJson !== rootKfcPackageJson || version !== "0.0.0-development") {
               throw new Error(`Pepr resolved kubernetes-fluent-client ${version}, not the candidate package`);
             }
           '

--- a/.github/workflows/uds-core.yml
+++ b/.github/workflows/uds-core.yml
@@ -77,8 +77,12 @@ jobs:
       - name: Install k3d
         shell: bash
         run: |
-          set -o pipefail
-          curl -sSfL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.9.0 bash
+          K3D_VERSION=v5.9.0
+          K3D_SHA256=06d8f25bc3a971c4eb29e0ff08429b180402db0f4dec838c9eac427e296800a0
+          K3D_BIN="${RUNNER_TEMP}/k3d"
+          curl -sSfL --output "${K3D_BIN}" "https://github.com/k3d-io/k3d/releases/download/${K3D_VERSION}/k3d-linux-amd64"
+          echo "${K3D_SHA256}  ${K3D_BIN}" | sha256sum --check --strict
+          sudo install -m 0755 "${K3D_BIN}" /usr/local/bin/k3d
           k3d version
 
       - name: Install the candidate package for Pepr

--- a/.github/workflows/uds-core.yml
+++ b/.github/workflows/uds-core.yml
@@ -1,0 +1,105 @@
+name: UDS Core Smoke Test
+
+on:
+  merge_group:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - LICENSE
+      - CODEOWNERS
+      - "**.md"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
+
+permissions: read-all
+
+jobs:
+  package:
+    name: package kubernetes-fluent-client
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kubernetes-fluent-client-package
+          path: kubernetes-fluent-client-0.0.0-development.tgz
+          if-no-files-found: error
+          retention-days: 1
+
+  uds-core:
+    name: uds-core slim-dev
+    runs-on: ubuntu-latest
+    needs: package
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Download package artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: kubernetes-fluent-client-package
+          path: ${{ github.workspace }}
+
+      - name: Checkout UDS Core
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: defenseunicorns/uds-core
+          path: uds-core
+
+      - name: Install UDS CLI
+        uses: defenseunicorns/setup-uds@d6add59d4c2ca789ed7c92741e91bd340b4e950b # v1.0.2
+        with:
+          version: v0.36.0
+
+      - name: Install k3d
+        shell: bash
+        run: |
+          set -o pipefail
+          curl -sSfL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.9.0 bash
+          k3d version
+
+      - name: Install the candidate package for Pepr
+        working-directory: uds-core
+        env:
+          KFC_TGZ: ${{ github.workspace }}/kubernetes-fluent-client-0.0.0-development.tgz
+        run: |
+          npm pkg set "overrides.kubernetes-fluent-client=file:${KFC_TGZ}"
+          npm install --ignore-scripts
+          node --eval '
+            const path = require("node:path");
+            const peprRoot = path.dirname(require.resolve("pepr/package.json"));
+            const kfcPackageJson = require.resolve("kubernetes-fluent-client/package.json", {
+              paths: [peprRoot],
+            });
+            const { version } = require(kfcPackageJson);
+            if (version !== "0.0.0-development") {
+              throw new Error(`Pepr resolved kubernetes-fluent-client ${version}, not the candidate package`);
+            }
+          '
+
+      - name: Run UDS Core slim-dev smoke test
+        working-directory: uds-core
+        run: uds run slim-dev --no-progress

--- a/package.json
+++ b/package.json
@@ -16,6 +16,16 @@
       "import": "./dist/dist.js",
       "default": "./dist/dist.js"
     },
+    "./dist/*.js": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
+    },
+    "./dist/*": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
+    },
     "./test": {
       "types": "./dist/test/index.d.ts",
       "import": "./dist/test/index.js",

--- a/src/test/verify-package.test.ts
+++ b/src/test/verify-package.test.ts
@@ -103,9 +103,11 @@ describe("published package", () => {
           import * as vitestConfigEntry from ${JSON.stringify(`${packageJson.name}/test/vitest`)};
           import * as vitestSetupEntry from ${JSON.stringify(`${packageJson.name}/test/vitest/setup`)};
           import ${JSON.stringify(`${packageJson.name}/dist/fetch.js`)};
+          import * as legacySharedTypesEntry from ${JSON.stringify(`${packageJson.name}/dist/fluent/shared-types`)};
 
           if (rootEntry.WatchPhase.Added !== "ADDED") throw new Error("WatchPhase is unavailable");
           if (legacyDistEntry.WatchPhase !== rootEntry.WatchPhase) throw new Error("Legacy dist entry does not export the root API");
+          if (legacySharedTypesEntry.WatchPhase !== rootEntry.WatchPhase) throw new Error("Legacy extensionless deep import does not export WatchPhase");
           if (typeof rootEntry.Watcher !== "function") throw new Error("Watcher is unavailable");
           if (typeof vitestConfigEntry.defineKubernetesTestConfig !== "function") throw new Error("Vitest config helper is unavailable");
           if ("setupKubernetesPreflight" in vitestConfigEntry) throw new Error("Vitest config entry exports setup helpers");
@@ -146,13 +148,16 @@ describe("published package", () => {
       consumerSource,
       'import { WatchEvent, WatchPhase, Watcher, type K8sInit, type KubernetesListObject, type WatchCfg, type WatcherType } from "kubernetes-fluent-client";\n' +
         'import { K8s as LegacyK8s } from "kubernetes-fluent-client/dist";\n' +
+        'import { WatchPhase as LegacyWatchPhase } from "kubernetes-fluent-client/dist/fluent/shared-types";\n' +
+        'import type { WatcherType as LegacyWatcherType } from "kubernetes-fluent-client/dist/fluent/types";\n' +
         "const phase = WatchPhase.Added;\n" +
         "const event = WatchEvent.CONNECT;\n" +
         "void phase;\n" +
         "void event;\n" +
         "void Watcher;\n" +
         "void LegacyK8s;\n" +
-        "type PublicFluentTypes = [K8sInit<any, any>, KubernetesListObject<any>, WatchCfg, WatcherType<any>];\n" +
+        "void LegacyWatchPhase;\n" +
+        "type PublicFluentTypes = [K8sInit<any, any>, KubernetesListObject<any>, WatchCfg, WatcherType<any>, LegacyWatcherType<any>];\n" +
         "void (null as unknown as PublicFluentTypes);\n",
     );
     execFileSync(

--- a/src/test/verify-package.test.ts
+++ b/src/test/verify-package.test.ts
@@ -148,6 +148,7 @@ describe("published package", () => {
       consumerSource,
       'import { WatchEvent, WatchPhase, Watcher, type K8sInit, type KubernetesListObject, type WatchCfg, type WatcherType } from "kubernetes-fluent-client";\n' +
         'import { K8s as LegacyK8s } from "kubernetes-fluent-client/dist";\n' +
+        'import { fetch as LegacyFetch } from "kubernetes-fluent-client/dist/fetch.js";\n' +
         'import { WatchPhase as LegacyWatchPhase } from "kubernetes-fluent-client/dist/fluent/shared-types";\n' +
         'import type { WatcherType as LegacyWatcherType } from "kubernetes-fluent-client/dist/fluent/types";\n' +
         "const phase = WatchPhase.Added;\n" +
@@ -156,6 +157,7 @@ describe("published package", () => {
         "void event;\n" +
         "void Watcher;\n" +
         "void LegacyK8s;\n" +
+        "void LegacyFetch;\n" +
         "void LegacyWatchPhase;\n" +
         "type PublicFluentTypes = [K8sInit<any, any>, KubernetesListObject<any>, WatchCfg, WatcherType<any>, LegacyWatcherType<any>];\n" +
         "void (null as unknown as PublicFluentTypes);\n",


### PR DESCRIPTION
## Summary

- preserve explicit JavaScript imports under `kubernetes-fluent-client/dist/**`
- support extensionless legacy deep imports by resolving emitted `.js` and `.d.ts` artifacts
- cover packed-consumer runtime and NodeNext type resolution while retaining the deprecated `dist` barrel behavior

## Validation

- `npm run build`
- `npm test` (286 tests passed)
- `npm run format:check` *(blocked by pre-existing Prettier drift in `src/fluent/utils.ts` and `src/postProcessing.ts`; edited files are formatted)*